### PR TITLE
Added method to customize CredentialsProvider used by the WebClient

### DIFF
--- a/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.http.client.CredentialsProvider;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
@@ -259,7 +260,6 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
   static BrowserVersion determineBrowserVersion(Capabilities capabilities) {
     String browserName = null;
     String browserVersion = null;
-
     String rawVersion = capabilities.getVersion();
     String[] splitVersion = rawVersion == null ? new String[0] : rawVersion.split("-");
     if (splitVersion.length > 1) {
@@ -485,6 +485,15 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
     proxyConfig = new ProxyConfig();
     proxyConfig.setProxyAutoConfigUrl(autoProxyUrl);
     getWebClient().getOptions().setProxyConfig(proxyConfig);
+  }
+
+  /**
+   * Sets credentials provider used by WebClient
+   *
+   * @param credentialsProvider Provider to use by the WebClient
+   */
+  public void setCredentialsProvider(final CredentialsProvider credentialsProvider) {
+    getWebClient().setCredentialsProvider(credentialsProvider);
   }
 
   @Override


### PR DESCRIPTION
It addresses the issue #1 so it will be possible to set CredentialsProvider used by the WebClient.