### PR TITLE
Add capability to set up Html Unit browser language

### DIFF
--- a/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
@@ -152,6 +152,8 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
   public static final String INVALIDSELECTIONERROR =
       "The xpath expression '%s' selected an object of type '%s' instead of a WebElement";
 
+  public static final String BROWSER_LANGUAGE_CAPABILITY = "browserLanguage";
+
   /**
    * Constructs a new instance with JavaScript disabled,
    * and the {@link BrowserVersion#getDefault() default} BrowserVersion.
@@ -277,29 +279,36 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
       browserVersion = capabilities.getVersion();
     }
 
+    BrowserVersion browserVersionObject = BrowserVersion.getDefault();
+
     if (BrowserType.FIREFOX.equals(browserName)) {
       try {
         int version = Integer.parseInt(browserVersion);
         switch (version) {
           case 38:
-            return BrowserVersion.FIREFOX_38;
+            browserVersionObject = BrowserVersion.FIREFOX_38;
           default:
-            return BrowserVersion.FIREFOX_45;
+            browserVersionObject = BrowserVersion.FIREFOX_45;
         }
       } catch (NumberFormatException e) {
-          return BrowserVersion.FIREFOX_45;
+          browserVersionObject = BrowserVersion.FIREFOX_45;
       }
     }
 
     if (BrowserType.CHROME.equals(browserName)) {
-      return BrowserVersion.CHROME;
+      browserVersionObject = BrowserVersion.CHROME;
     }
 
     if (BrowserType.IE.equals(browserName)) {
-      return BrowserVersion.INTERNET_EXPLORER;
+      browserVersionObject = BrowserVersion.INTERNET_EXPLORER;
     }
 
-    return BrowserVersion.getDefault();
+    Object rawLanguage = capabilities.getCapability(BROWSER_LANGUAGE_CAPABILITY);
+    if (rawLanguage instanceof String) {
+      browserVersionObject.setBrowserLanguage((String) rawLanguage);
+    }
+
+    return browserVersionObject;
   }
 
   private WebClient createWebClient(BrowserVersion version) {

--- a/src/test/java/org/openqa/selenium/htmlunit/HtmlUnitCapabilitiesTest.java
+++ b/src/test/java/org/openqa/selenium/htmlunit/HtmlUnitCapabilitiesTest.java
@@ -87,4 +87,15 @@ public class HtmlUnitCapabilitiesTest {
     assertFalse(jsDisabled.isJavascriptEnabled());
   }
 
+  @Test
+  public void configurationOfBrowserLanguage() {
+    String browserLanguage = "es-ES";
+
+    DesiredCapabilities capabilities = DesiredCapabilities.htmlUnit();
+    capabilities.setCapability(HtmlUnitDriver.BROWSER_LANGUAGE_CAPABILITY, browserLanguage);
+
+    assertEquals(HtmlUnitDriver.determineBrowserVersion(capabilities).getBrowserLanguage(),
+            browserLanguage);
+  }
+
 }


### PR DESCRIPTION
This feature will allow users of HtmlUnitDriver to set up custom browser
language, when using it through RemoteWebDriver.

When ‘browserLanguage’ capability is set, HtmlUnitDriver will configure
HtmlUnit browser language, in order to set ‘Accept-Language’ header
to each request, with the value specified in the capability.

I've signed the CLA.