### PR TITLE
Upgrade HtmlUnit version to 2.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>net.sourceforge.htmlunit</groupId>
         <artifactId>htmlunit</artifactId>
-        <version>2.22</version>
+        <version>2.23</version>
         <exclusions>
           <exclusion>
             <groupId>org.eclipse.jetty.websocket</groupId>

--- a/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
@@ -1408,12 +1408,20 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
 
     @Override
     public void back() {
-      getCurrentWindow().getHistory().back();
+      try {
+        getCurrentWindow().getHistory().back();
+      } catch (IOException e) {
+        throw new WebDriverException(e);
+      }
     }
 
     @Override
     public void forward() {
-      getCurrentWindow().getHistory().forward();
+      try {
+        getCurrentWindow().getHistory().forward();
+      } catch (IOException e) {
+        throw new WebDriverException(e);
+      }
     }
 
     @Override


### PR DESCRIPTION
Now IOException is thrown by forward() and back() methods.

I've signed the CLA.