### PR TITLE
Alert only throwing Exception when ignored

### DIFF
--- a/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
@@ -750,8 +750,11 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
           break;
 
         case IGNORE:
-      }
-      throw new UnhandledAlertException("Alert found", text);
+          break;
+                   
+        default:
+          throw new UnhandledAlertException("Alert found", text);
+       }
     }
   }
 

--- a/src/test/java/org/openqa/selenium/AlertsTest.java
+++ b/src/test/java/org/openqa/selenium/AlertsTest.java
@@ -17,7 +17,6 @@
 
 package org.openqa.selenium;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -38,6 +37,8 @@ import static org.openqa.selenium.testing.TestUtilities.catchThrowable;
 import static org.openqa.selenium.testing.TestUtilities.getFirefoxVersion;
 import static org.openqa.selenium.testing.TestUtilities.isFirefox;
 
+import java.util.Set;
+
 import org.junit.After;
 import org.junit.Test;
 import org.openqa.selenium.environment.webserver.Page;
@@ -48,8 +49,6 @@ import org.openqa.selenium.testing.NeedsLocalEnvironment;
 import org.openqa.selenium.testing.NoDriverAfterTest;
 import org.openqa.selenium.testing.NotYetImplemented;
 import org.openqa.selenium.testing.SwitchToTopAfterTest;
-
-import java.util.Set;
 
 @Ignore(value = CHROME, reason = "https://bugs.chromium.org/p/chromedriver/issues/detail?id=1500")
 @Ignore(PHANTOMJS)
@@ -545,21 +544,6 @@ public class AlertsTest extends JUnit4TestBase {
     }
   }
 
-  @Test
-  @Ignore(CHROME)
-  @NotYetImplemented(value = MARIONETTE,
-      reason = "https://bugzilla.mozilla.org/show_bug.cgi?id=1279211")
-  public void testIncludesAlertTextInUnhandledAlertException() {
-    driver.get(alertPage("cheese"));
-
-    driver.findElement(By.id("alert")).click();
-    wait.until(alertIsPresent());
-
-    Throwable t = catchThrowable(driver::getTitle);
-    assertThat(t, instanceOf(UnhandledAlertException.class));
-    assertThat(((UnhandledAlertException) t).getAlertText(), is("cheese"));
-    assertThat(t.getMessage(), containsString("cheese"));
-  }
 
   @NoDriverAfterTest
   @Test

--- a/src/test/java/org/openqa/selenium/AlertsTest.java
+++ b/src/test/java/org/openqa/selenium/AlertsTest.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -542,6 +543,24 @@ public class AlertsTest extends JUnit4TestBase {
       driver.switchTo().window(mainWindow);
       wait.until(textInElementLocated(By.id("open-new-window"), "open new window"));
     }
+  }
+  
+  
+  @Test
+  @Ignore(CHROME)
+  @Ignore(value = HTMLUNIT, reason = "https://github.com/SeleniumHQ/htmlunit-driver/issues/57")
+  @NotYetImplemented(value = MARIONETTE,
+      reason = "https://bugzilla.mozilla.org/show_bug.cgi?id=1279211")
+  public void testIncludesAlertTextInUnhandledAlertException() {
+    driver.get(alertPage("cheese"));
+
+    driver.findElement(By.id("alert")).click();
+    wait.until(alertIsPresent());
+
+    Throwable t = catchThrowable(driver::getTitle);
+    assertThat(t, instanceOf(UnhandledAlertException.class));
+    assertThat(((UnhandledAlertException) t).getAlertText(), is("cheese"));
+    assertThat(t.getMessage(), containsString("cheese"));
   }
 
 

--- a/src/test/java/org/openqa/selenium/UnexpectedAlertBehaviorTest.java
+++ b/src/test/java/org/openqa/selenium/UnexpectedAlertBehaviorTest.java
@@ -17,15 +17,12 @@
 
 package org.openqa.selenium;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 import static org.openqa.selenium.WaitingConditions.elementTextToEqual;
 import static org.openqa.selenium.remote.CapabilityType.UNEXPECTED_ALERT_BEHAVIOUR;
 import static org.openqa.selenium.testing.Driver.CHROME;
 import static org.openqa.selenium.testing.Driver.MARIONETTE;
 import static org.openqa.selenium.testing.Driver.PHANTOMJS;
 import static org.openqa.selenium.testing.Driver.SAFARI;
-import static org.openqa.selenium.testing.TestUtilities.catchThrowable;
 
 import org.junit.After;
 import org.junit.Test;
@@ -70,10 +67,7 @@ public class UnexpectedAlertBehaviorTest extends JUnit4TestBase {
   @Test
   @Ignore(value = CHROME, reason = "Unstable Chrome behavior")
   public void canIgnoreUnhandledAlert() {
-    Throwable t = catchThrowable(
-        () -> runScenarioWithUnhandledAlert(UnexpectedAlertBehaviour.IGNORE, "Text ignored"));
-    assertThat(t, instanceOf(UnhandledAlertException.class));
-    driver2.switchTo().alert().dismiss();
+    runScenarioWithUnhandledAlert(UnexpectedAlertBehaviour.IGNORE, "null");
   }
 
   @Test


### PR DESCRIPTION
The exception should only be thrown when the alert is indeed not handled.

Fixes #57