### PR TITLE
Add HtmlUnitDriver Executor

### DIFF
--- a/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -183,7 +184,7 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
   private Condition mainCondition = conditionLock.newCondition();
   private boolean runAsyncRunning;
   private RuntimeException exception;
-  private Executor executor = task -> new Thread(task).run();
+  private Executor executor = Executors.newCachedThreadPool();
 
   /**
    * Constructs a new instance with JavaScript disabled,

--- a/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitDriver.java
@@ -38,6 +38,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -182,6 +183,7 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
   private Condition mainCondition = conditionLock.newCondition();
   private boolean runAsyncRunning;
   private RuntimeException exception;
+  private Executor executor = task -> new Thread(task).run();
 
   /**
    * Constructs a new instance with JavaScript disabled,
@@ -419,7 +421,7 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
     }
     
     exception = null;
-    new Thread(() -> {
+    Runnable wrapped = () -> {
       try {
         r.run();
       }
@@ -432,7 +434,8 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
         runAsyncRunning = false;
         conditionLock.unlock();
       }
-    }).start();
+    };
+    executor.execute(wrapped);
 
     if (loadStrategyWait) {
       mainCondition.awaitUninterruptibly();
@@ -627,6 +630,17 @@ public class HtmlUnitDriver implements WebDriver, JavascriptExecutor,
       }
     }
     getWebClient().getOptions().setProxyConfig(proxyConfig);
+  }
+
+  /**
+   * Sets the {@link Executor} to be used for submitting async tasks to
+   * @param executor the {@link Executor} to use
+   */
+  public void setExecutor(Executor executor) {
+    if (executor == null) {
+      throw new IllegalArgumentException("executor cannot be null");
+    }
+    this.executor = executor;
   }
 
   /**


### PR DESCRIPTION
Staring with `HtmlUnitDriver` 2.26 tasks have been submitted asynchronously in the package private `runAsync` method. By running the tasks asynchronously performance improvements can be seen, but the current approach has limitations:

1) A new `Thread` is created for every task which is resource intensive
2) There is no way to disable concurrency (i.e. to debug application issues)
3) `ThreadLocal` context will be lost without a suitable way to transfer to the new Thread. This impacts Spring Framework's `MockMvc` integration which leverages a `ThreadLocal` to run a test with a specified user

This pull request adds an Executor to `HtmlUnitDriver` which resolves all of the issues above. The first commit is as passive as possible and preserves the new `Thread` per task model currently in place. The second commit updates the default to leverage a cached `Thread` pool instead.