### PR TITLE
Add test case for Select Element

### DIFF
--- a/src/test/java/org/openqa/selenium/SelectElementHandlingTest.java
+++ b/src/test/java/org/openqa/selenium/SelectElementHandlingTest.java
@@ -17,6 +17,7 @@
 
 package org.openqa.selenium;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -26,6 +27,7 @@ import static org.openqa.selenium.testing.Driver.SAFARI;
 import java.util.List;
 
 import org.junit.Test;
+import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.testing.JUnit4TestBase;
 import org.openqa.selenium.testing.NotYetImplemented;
 
@@ -163,5 +165,16 @@ public class SelectElementHandlingTest extends JUnit4TestBase {
     WebElement element = driver.findElement(By.cssSelector("#transparent option"));
     element.click();
     assertTrue("Expected to be selected", element.isSelected());
+  }
+
+  @Test
+  public void testConvertWebElementToSelectComponent() {
+    driver.get(pages.selectPage);
+
+    WebElement element = driver.findElement(By.id("selectWithoutMultiple"));
+    assertThat(element, notNullValue());
+
+    Select select = new Select(element);
+    assertThat(select, notNullValue());
   }
 }


### PR DESCRIPTION
I've added test case for Select Element in order to avoid errors as in #106 . 
@rbri I think it's sufficient to only include it to the _SelectElementHandlingTest_ class. WDYT? You can extend the tests lately.