### PR TITLE
Implement a new HtmlUnitDriverOptions (Capabilities) class

### DIFF
--- a/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitWebElement.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/HtmlUnitWebElement.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.htmlunit.ScriptResult;
@@ -62,6 +63,7 @@ import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.WrapsElement;
 import org.openqa.selenium.interactions.Coordinates;
 import org.openqa.selenium.interactions.Locatable;
+import org.openqa.selenium.remote.Dialect;
 import org.openqa.selenium.support.Color;
 import org.openqa.selenium.support.Colors;
 import org.w3c.dom.Attr;
@@ -733,4 +735,7 @@ public class HtmlUnitWebElement implements WrapsDriver, WebElement, Coordinates,
         return id_;
     }
 
+    public Map<String, Object> toJson() {
+        return Map.of(Dialect.W3C.getEncodedElementKey(), getId());
+    }
 }

--- a/src/main/java/org/openqa/selenium/htmlunit/options/BrowserVersionTrait.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/options/BrowserVersionTrait.java
@@ -1,0 +1,567 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import java.util.Map;
+import java.util.TimeZone;
+import org.htmlunit.BrowserVersion;
+import org.htmlunit.BrowserVersion.BrowserVersionBuilder;
+
+public enum BrowserVersionTrait implements BrowserVersionTraitNames, OptionEnum {
+    /**
+     * Returns the numeric code for the browser represented by this <b>BrowserVersion</b>.
+     * <p>
+     * property: <b>webdriver.htmlunit.numericCode</b><br>
+     * type: {@code int}<br>
+     * default: {@code 0}
+     */
+    NUMERIC_CODE(optNumericCode, int.class, 0) {
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getBrowserVersionNumeric();
+        }
+    },
+    
+    /**
+     * Returns the nickname for the browser represented by this <b>BrowserVersion</b>.
+     * <p>
+     * property: <b>webdriver.htmlunit.nickname</b><br>
+     * type: {@code String}<br>
+     * default: {@code null}
+     */
+    NICKNAME(optNickname, String.class, null) {
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getNickname();
+        }
+    },
+    
+    /**
+     * Returns the application version, for example "4.0 (compatible; MSIE 6.0b; Windows 98)".
+     * <p>
+     * property: <b>webdriver.htmlunit.applicationVersion</b><br>
+     * type: {@code String}<br>
+     * default: {@code null}<br>
+     * see: <a href="http://msdn.microsoft.com/en-us/library/ms533080.aspx">MSDN documentation</a>
+     */
+    APPLICATION_VERSION(optApplicationVersion, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setApplicationVersion(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getApplicationVersion();
+        }
+    },
+    
+    /**
+     * Returns the user agent string, for example "Mozilla/4.0 (compatible; MSIE 6.0b; Windows 98)".
+     * <p>
+     * property: <b>webdriver.htmlunit.userAgent</b><br>
+     * type: {@link String}<br>
+     * default: {@code null}
+     */
+    USER_AGENT(optUserAgent, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setUserAgent(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getUserAgent();
+        }
+    },
+
+    /**
+     * Returns the application name, for example "Microsoft Internet Explorer".
+     * <p>
+     * property: <b>webdriver.htmlunit.applicationName</b><br>
+     * type: {@code String}<br>
+     * default: {@code null}<br>
+     * @see <a href="http://msdn.microsoft.com/en-us/library/ms533079.aspx">MSDN documentation</a>
+     */
+    APPLICATION_NAME(optApplicationName, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setApplicationName(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getApplicationName();
+        }
+    },
+    
+    /**
+     * Returns the application code name, for example "Mozilla".
+     * <p>
+     * property: <b>webdriver.htmlunit.applicationCodeName</b><br>
+     * type: {@code String}<br>
+     * default: "Mozilla"<br>
+     * see: <a href="http://msdn.microsoft.com/en-us/library/ms533077.aspx">MSDN documentation</a>
+     */
+    APPLICATION_CODE_NAME(optApplicationCodeName, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setApplicationCodeName(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getApplicationCodeName();
+        }
+    },
+    
+    /**
+     * Returns the application minor version, for example "0".
+     * <p>
+     * property: <b>webdriver.htmlunit.applicationMinorVersion</b><br>
+     * type: {@code String}<br>
+     * default: "0"<br>
+     * see: <a href="http://msdn.microsoft.com/en-us/library/ms533078.aspx">MSDN documentation</a>
+     */
+    APPLICATION_MINOR_VERSION(optApplicationMinorVersion, String.class, "0") {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setApplicationMinorVersion(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getApplicationMinorVersion();
+        }
+    },
+    
+    /**
+     * Returns the browser vendor, for example "Google Inc.".
+     * <p>
+     * property: <b>webdriver.htmlunit.vendor</b><br>
+     * type: {@code String}<br>
+     * default: ""
+     */
+    VENDOR(optVendor, String.class, "") {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setVendor(TypeCodec.decodeString(value));            
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getVendor();
+        }
+    },
+
+    /**
+     * Returns the browser language, for example "en-US".
+     * <p>
+     * property: <b>webdriver.htmlunit.browserLanguage</b><br>
+     * type: {@link String}<br>
+     * default: "en_US"
+     */
+    BROWSER_LANGUAGE(optBrowserLanguage, String.class, "en-US") {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setBrowserLanguage(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getBrowserLanguage();
+        }
+    },
+
+    /**
+     * Returns {@code true} if the browser is currently online.
+     * <p>
+     * property: <b>webdriver.htmlunit.isOnline</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code true}<br>
+     * see: <a href="http://msdn.microsoft.com/en-us/library/ms534307.aspx">MSDN documentation</a>
+     */
+    IS_ONLINE(optIsOnline, boolean.class, true) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setOnLine(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.isOnLine();
+        }
+    },
+
+    /**
+     * Returns the platform on which the application is running, for example "Win32".
+     * <p>
+     * property: <b>webdriver.htmlunit.platform</b><br>
+     * type: {@code String}<br>
+     * default: "Win32"<br>
+     * see: <a href="http://msdn.microsoft.com/en-us/library/ms534340.aspx">MSDN documentation</a>
+     */
+    PLATFORM(optPlatform, String.class, "Win32") {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setPlatform(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getPlatform();
+        }
+    },
+
+    /**
+     * Returns the system {@link TimeZone}.
+     * <p>
+     * property: <b>webdriver.htmlunit.systemTimezone</b><br>
+     * type: {@link TimeZone}<br>
+     * default: TimeZone.getTimeZone("America/New_York")
+     */
+    SYSTEM_TIMEZONE(optSystemTimezone, TimeZone.class, TimeZone.getTimeZone("America/New_York")) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setSystemTimezone(TypeCodec.decodeTimeZone(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getSystemTimezone();
+        }
+    },
+
+    /**
+     * Returns the value used by the browser for the {@code Accept-Encoding} header.
+     * <p>
+     * property: <b>webdriver.htmlunit.acceptEncodingHeader</b><br>
+     * type: {@link String}<br>
+     * default: {@code null}
+     */
+    ACCEPT_ENCODING_HEADER(optAcceptEncodingHeader, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setAcceptEncodingHeader(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getAcceptEncodingHeader();
+        }
+    },
+
+    /**
+     * Returns the value used by the browser for the {@code Accept-Language} header.
+     * <p>
+     * property: <b>webdriver.htmlunit.acceptLanguageHeader</b><br>
+     * type: {@link String}<br>
+     * default: {@code null}
+     */
+    ACCEPT_LANGUAGE_HEADER(optAcceptLanguageHeader, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setAcceptLanguageHeader(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getAcceptLanguageHeader();
+        }
+    },
+
+    /**
+     * Returns the value used by the browser for the {@code Accept} header if requesting a page.
+     * <p>
+     * property: <b>webdriver.htmlunit.htmlAcceptHeader</b><br>
+     * type: {@link String}<br>
+     * default: {@code null}
+     */
+    HTML_ACCEPT_HEADER(optHtmlAcceptHeader, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setHtmlAcceptHeader(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getHtmlAcceptHeader();
+        }
+    },
+
+    /**
+     * Returns the value used by the browser for the {@code Accept} header
+     * if requesting an image.
+     * <p>
+     * property: <b>webdriver.htmlunit.imgAcceptHeader</b><br>
+     * type: {@link String}<br>
+     * default: {@code null}
+     */
+    IMG_ACCEPT_HEADER(optImgAcceptHeader, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setImgAcceptHeader(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getImgAcceptHeader();
+        }
+    },
+
+    /**
+     * Returns the value used by the browser for the {@code Accept} header
+     * if requesting a CSS declaration.
+     * <p>
+     * property: <b>webdriver.htmlunit.cssAcceptHeader</b><br>
+     * type: {@link String}<br>
+     * default: {@code null}
+     */
+    CSS_ACCEPT_HEADER(optCssAcceptHeader, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setCssAcceptHeader(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getCssAcceptHeader();
+        }
+    },
+
+    /**
+     * Returns the value used by the browser for the {@code Accept} header
+     * if requesting a script.
+     * <p>
+     * property: <b>webdriver.htmlunit.scriptAcceptHeader</b><br>
+     * type: {@link String}<br>
+     * default: {@code null}
+     */
+    SCRIPT_ACCEPT_HEADER(optScriptAcceptHeader, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setScriptAcceptHeader(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getScriptAcceptHeader();
+        }
+    },
+
+    /**
+     * Returns the value used by the browser for the {@code Accept} header
+     * if performing an XMLHttpRequest.
+     * <p>
+     * property: <b>webdriver.htmlunit.xmlHttpRequestAcceptHeader</b><br>
+     * type: {@link String}<br>
+     * default: {@code null}
+     */
+    XML_HTTP_REQUEST_ACCEPT_HEADER(optXmlHttpRequestAcceptHeader, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setXmlHttpRequestAcceptHeader(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getXmlHttpRequestAcceptHeader();
+        }
+    },
+
+    /**
+     * Returns the value used by the browser for the {@code Sec-CH-UA} header.
+     * <p>
+     * property: <b>webdriver.htmlunit.secClientHintUserAgentHeader</b><br>
+     * type: {@link String}<br>
+     * default: {@code null}
+     */
+    SEC_CLIENT_HINT_USER_AGENT_HEADER(optSecClientHintUserAgentHeader, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setSecClientHintUserAgentHeader(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getSecClientHintUserAgentHeader();
+        }
+    },
+
+    /**
+     * Returns the value used by the browser for the {@code Sec-CH-UA-Platform} header.
+     * <p>
+     * property: <b>webdriver.htmlunit.secClientHintUserAgentPlatformHeader</b><br>
+     * type: {@link String}<br>
+     * default: {@code null}
+     */
+    SEC_CLIENT_HINT_USER_AGENT_PLATFORM_HEADER(optSecClientHintUserAgentPlatformHeader, String.class, null) {
+        @Override
+        public void apply(final Object value, final BrowserVersionBuilder builder) {
+            builder.setSecClientHintUserAgentPlatformHeader(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final BrowserVersion version) {
+            return version.getSecClientHintUserAgentPlatformHeader();
+        }
+    };
+
+    public final String key;
+    public final String name;
+    public final Class<?> type;
+    public final Object initial;
+    
+    BrowserVersionTrait(final String key, final Class<?> type, final Object initial) {
+        this.key = key;
+        this.name = "webdriver.htmlunit.browserVersionTrait." + key;
+        this.type = type;
+        this.initial = initial;
+    }
+    
+    @Override
+    public String getCapabilityKey() {
+        return key;
+    }
+    
+    @Override
+    public String getPropertyName() {
+        return name;
+    }
+    
+    @Override
+    public Class<?> getOptionType() {
+        return type;
+    }
+    
+    @Override
+    public Object getDefaultValue() {
+        return initial;
+    }
+    
+    /**
+     * Determine if the specified value matches the default for this trait.
+     * 
+     * @param value value to be evaluated
+     * @return {@code true} if specified value matches the default value; otherwise {@code false}
+     */
+    @Override
+    public boolean isDefaultValue(final Object value) {
+        if (initial == null) return value == null;
+        if (value == null) return false;
+        return value.equals(initial);
+    }
+    
+    /**
+     * Apply the value of the system property associated with this trait to the specified options map.
+     * 
+     * @param optionsMap browser version options map
+     */
+    @Override
+    public
+    void applyPropertyTo(Map<String, Object> optionsMap) {
+        String value = System.getProperty(name);
+        if (value != null) {
+            optionsMap.put(key, decode(value));
+            System.clearProperty(key);
+        }
+    }
+    
+    /**
+     * Encode the specified value according to the type of this trait.
+     * 
+     * @param value value to be encoded
+     * @return trait-specific encoding for specified value
+     */
+    @Override
+    public Object encode(final Object value) {
+        switch (this.type.getName()) {
+        case "boolean":
+        case "int":
+        case "java.lang.String":
+            return value;
+        case "java.util.TimeZone":
+            return TypeCodec.encodeTimeZone(value);
+        }
+        throw new IllegalStateException(
+                String.format("Unsupported type '%s' specified for option [%s]; value is of type: %s",
+                this.type.getName(), this.toString(), TypeCodec.getClassName(value)));
+    }
+    
+    /**
+     * Decode the specified value according to the type of this trait.
+     * 
+     * @param value value to be decoded
+     * @return trait-specific decoding for specified value
+     */
+    @Override
+    public Object decode(final Object value) {
+        switch (this.type.getName()) {
+        case "boolean":
+            return TypeCodec.decodeBoolean(value);
+        case "int":
+            return TypeCodec.decodeInt(value);
+        case "java.lang.String":
+            return TypeCodec.decodeString(value);
+        case "java.util.TimeZone":
+            return TypeCodec.decodeTimeZone(value);
+        }
+        throw new IllegalStateException(
+                String.format("Unsupported type '%s' specified for option [%s]; value is of type: %s",
+                this.type.getName(), this.toString(), TypeCodec.getClassName(value)));
+    }
+    
+    /**
+     * Apply the specified value for this trait into the provided browser version builder.
+     * 
+     * @param value value to be inserted
+     * @param builder {@link BrowserVersionBuilder} object
+     */
+    public void apply(final Object value, final BrowserVersionBuilder builder) {
+        throw new UnsupportedOperationException(
+                String.format("Trait '%s' does not support value insertion", this.toString()));
+    }
+    
+    /**
+     * Obtain the value for this trait from the specified browser version object.
+     * 
+     * @param version {@link BrowserVersion} object
+     * @return value for this trait
+     */
+    public Object obtain(final BrowserVersion version) {
+        return null;
+    }
+    
+    public static BrowserVersionTrait fromCapabilityKey(final String key) {
+        for (BrowserVersionTrait trait : BrowserVersionTrait.values()) {
+            if (trait.key.equals(key)) {
+                return trait;
+            }
+        }
+        return null;
+    }
+    
+    public static BrowserVersionTrait fromPropertyName(final String name) {
+        for (BrowserVersionTrait trait : BrowserVersionTrait.values()) {
+            if (trait.name.equals(name)) {
+                return trait;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/openqa/selenium/htmlunit/options/BrowserVersionTraitNames.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/options/BrowserVersionTraitNames.java
@@ -1,0 +1,43 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+public interface BrowserVersionTraitNames {
+    String SECTION = "browser-version-trait";
+    String optNumericCode = "numericCode";
+    String optNickname = "nickname";
+    String optApplicationVersion = "applicationVersion";
+    String optUserAgent = "userAgent";
+    String optApplicationName = "applicationName";
+    String optApplicationCodeName = "applicationCodeName";
+    String optApplicationMinorVersion = "applicationMinorVersion";
+    String optVendor = "vendor";
+    String optBrowserLanguage = "browserLanguage";
+    String optIsOnline = "isOnline";
+    String optPlatform = "platform";
+    String optSystemTimezone = "systemTimezone";
+    String optAcceptEncodingHeader = "acceptEncodingHeader";
+    String optAcceptLanguageHeader = "acceptLanguageHeader";
+    String optHtmlAcceptHeader = "htmlAcceptHeader";
+    String optImgAcceptHeader = "imgAcceptHeader";
+    String optCssAcceptHeader = "cssAcceptHeader";
+    String optScriptAcceptHeader = "scriptAcceptHeader";
+    String optXmlHttpRequestAcceptHeader = "xmlHttpRequestAcceptHeader";
+    String optSecClientHintUserAgentHeader = "secClientHintUserAgentHeader";
+    String optSecClientHintUserAgentPlatformHeader = "secClientHintUserAgentPlatformHeader";
+}

--- a/src/main/java/org/openqa/selenium/htmlunit/options/HtmlUnitDriverOptions.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/options/HtmlUnitDriverOptions.java
@@ -1,0 +1,432 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import static org.openqa.selenium.remote.Browser.HTMLUNIT;
+import static org.openqa.selenium.htmlunit.HtmlUnitDriver.JAVASCRIPT_ENABLED;
+import static org.openqa.selenium.htmlunit.HtmlUnitDriver.DOWNLOAD_IMAGES_CAPABILITY;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.KeyStore;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.htmlunit.BrowserVersion;
+import org.htmlunit.ProxyConfig;
+import org.htmlunit.WebClientOptions;
+import org.htmlunit.util.UrlUtils;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.htmlunit.BrowserVersionDeterminer;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.openqa.selenium.internal.Require;
+import org.openqa.selenium.remote.AbstractDriverOptions;
+import org.openqa.selenium.remote.CapabilityType;
+
+/**
+ * Class to manage options specific to {@link HtmlUnitDriver}.
+ *
+ * <p>Example usage:
+ *
+ * <pre><code>
+ * HtmlUnitDriverOptions options = new HtmlUnitDriverOptions()
+ *     .setWebClientVersion(BrowserVersion.FIREFOX_ESR)
+ *     .setJavaScriptEnabled(true);
+ *
+ * // For use with HtmlUnitDriver:
+ * HtmlUnitDriver driver = new HtmlUnitDriver(options);
+ *
+ * // For use with RemoteWebDriver:
+ * RemoteWebDriver driver = new RemoteWebDriver(
+ *     new URL("http://localhost:4444/"),
+ *     new HtmlUnitDriverOptions());
+ * </code></pre>
+ * 
+ * <p>Getting/setting HtmlUnitDriver options:
+ * <p>
+ * In addition to methods for reading and writing specific <b>HtmlUnitDriver</b> options, you can use
+ * the standard {@link MutableCapabilities} API:
+ * <ul>
+ *     <li>{@link #is(String)}</li>
+ *     <li>{@link #getCapability(String)}</li>
+ *     <li>{@link #setCapability(String, Object)}</li>
+ * </ul>
+ * 
+ * <p>Example usage:
+ * 
+ * <pre><code>
+ * HtmlUnitDriverOptions options = new HtmlUnitDriverOptions();
+ * boolean popupBlockerEnabled = options.is(HtmlUnitOption.optPopupBlockerEnabled);
+ * // NOTE: See "Getting individual browser version traits" below
+ * String  browserLanguage = (String) options.getCapability(BrowserVersionTrait.optBrowserLanguage);
+ * options.setCapability(HtmlUnitOption.optGeolocationEnabled, true);
+ * </code></pre>
+ * 
+ * <p>Getting individual browser version traits:
+ * <p>
+ * <b>HtmlUnitDriverOption</b> contains a {@link BrowserVersion} which can be read and written directly: 
+ * <ul>
+ *     <li>{@link #getWebClientVersion()}</li>
+ *     <li>{@link #setWebClientVersion(BrowserVersion)}</li>
+ * </ul>
+ * The individual traits of the <b>BrowserVersion</b> object can be read directly as well via the standard
+ * {@link Capabilities} API. For example: 
+ * 
+ * <pre><code>
+ * HtmlUnitDriverOptions options = new HtmlUnitDriverOptions(BrowserVersion.EDGE);
+ * // System time zone accessed via BrowserVersion API
+ * TimeZone viaBrowserVersion = options.getWebClientVersion.getSystemTimezone();
+ * // System time zone accessed via standard Capabilities API
+ * TimeZone viaCapabilityName = (TimeZone) options.getCapability(BrowserVersionTrait.optSystemTimezone);
+ * </code></pre>
+ * 
+ * <b>NOTE</b>: Although <b>HtmlUnitDriverOptions</b> objects are mutable (their properties can be altered),
+ * the individual traits of the {@link BrowserVersion} object within these objects cannot be altered:
+ * 
+ * <pre><code>
+ * HtmlUnitDriverOptions options = new HtmlUnitDriverOptions(BrowserVersion.CHROME);
+ * options.setCapability(BrowserVersionTrait.optUserAgent, "HtmlUnitDriver emulating Google Chrome");
+ * // =&gt; UnsupporterOperationException: Individual browser version traits are immutable; 'optUserAgent' cannot be set
+ * </code></pre>
+ * 
+ * @since HtmlUnitDriver v4.21.0
+ * @see HtmlUnitOption
+ * @see BrowserVersionTrait
+ */
+@SuppressWarnings("serial")
+public class HtmlUnitDriverOptions extends AbstractDriverOptions<HtmlUnitDriverOptions> {
+
+    /**
+     * Key used to store a set of HtmlUnitDriverOptions in a {@link Capabilities}
+     * object.
+     */
+    public static final String HTMLUNIT_OPTIONS = "garg:htmlunitOptions";
+    
+    private WebClientOptions webClientOptions = new WebClientOptions();
+    private BrowserVersion webClientVersion = BrowserVersion.BEST_SUPPORTED;
+
+    public HtmlUnitDriverOptions() {
+        setCapability(CapabilityType.BROWSER_NAME, HTMLUNIT.browserName());
+        webClientOptions.setHomePage(UrlUtils.URL_ABOUT_BLANK.toString());
+        webClientOptions.setThrowExceptionOnFailingStatusCode(false);
+        webClientOptions.setPrintContentOnFailingStatusCode(false);
+        webClientOptions.setUseInsecureSSL(true);
+    }
+    
+    public HtmlUnitDriverOptions(final BrowserVersion version) {
+        this();
+        setWebClientVersion(version);
+    }
+    
+    public HtmlUnitDriverOptions(final BrowserVersion version, final boolean enableJavascript) {
+        this();
+        setWebClientVersion(version);
+        setJavaScriptEnabled(enableJavascript);
+    }
+    
+    public HtmlUnitDriverOptions(final Capabilities source) {
+        this();
+        if (source != null) {
+            // transfer mapped capabilities
+            source.asMap().forEach(this::setCapability);
+            // ensure browser name is correct
+            setCapability(CapabilityType.BROWSER_NAME, HTMLUNIT.browserName());
+            
+            if (source instanceof HtmlUnitDriverOptions) {
+                // transfer web client option from source capabilities
+                transfer(((HtmlUnitDriverOptions) source).webClientOptions, webClientOptions);
+                // copy web client version from source capabilities
+                webClientVersion = ((HtmlUnitDriverOptions) source).webClientVersion;
+            } else {
+                // get HtmlUnit options from standard capabilities
+                Object htmlunitOptions = source.getCapability(HTMLUNIT_OPTIONS);
+                // if capability was found
+                if (htmlunitOptions != null) {
+                    // import HtmlUnit options
+                    importOptions(htmlunitOptions);
+                    
+                    // remove encoded HtmlUnit options
+                    setCapability(HTMLUNIT_OPTIONS, (Object) null);
+                } else {
+                    // set web client version from standard capabilities
+                    webClientVersion = BrowserVersionDeterminer.determine(source);
+                }
+            }
+            
+            // if JAVASCRIPT_ENABLED has default value, but legacy capability is 'false'
+            if (isJavaScriptEnabled() && (Boolean.FALSE == source.getCapability(JAVASCRIPT_ENABLED))) {
+                // disable JavaScript support
+                setJavaScriptEnabled(false);
+            }
+            // if DOWNLOAD_IMAGES has default value, but legacy capability is 'true'
+            if (!isDownloadImages() && source.is(DOWNLOAD_IMAGES_CAPABILITY)) {
+                // enable image download
+                setDownloadImages(true);
+            }
+            
+            // remove legacy capabilities
+            super.setCapability(JAVASCRIPT_ENABLED, (Object) null);
+            super.setCapability(DOWNLOAD_IMAGES_CAPABILITY, (Object) null);
+        }
+    }
+
+    public HtmlUnitDriverOptions(final Map<String, Object> optionsMap) {
+        this(new MutableCapabilities(Require.nonNull("Source options map", optionsMap)));
+    }
+    
+    @Override
+    public Object getCapability(final String capabilityName) {
+        Require.nonNull("Capability name", capabilityName);
+        if (HTMLUNIT_OPTIONS.equals(capabilityName)) {
+            return exportOptions();
+        }
+        HtmlUnitOption option = HtmlUnitOption.fromCapabilityKey(capabilityName);
+        if (option != null) {
+            switch (option) {
+            case SSL_CLIENT_CERTIFICATE_PASSWORD:
+            case SSL_TRUST_STORE_PASSWORD:
+                return null;
+            case WEB_CLIENT_VERSION:
+                return webClientVersion;
+            default:
+                return option.obtain(webClientOptions);
+            }
+        }
+        BrowserVersionTrait trait = BrowserVersionTrait.fromCapabilityKey(capabilityName);
+        if (trait != null) {
+            return trait.obtain(webClientVersion);
+        }
+        return super.getCapability(capabilityName);
+    }
+
+    @Override
+    public void setCapability(final String capabilityName, final Object value) {
+        Require.nonNull("Capability name", capabilityName);
+        if (HTMLUNIT_OPTIONS.equals(capabilityName)) {
+            importOptions(value);
+            return;
+        }
+        HtmlUnitOption option = HtmlUnitOption.fromCapabilityKey(capabilityName);
+        if (option != null) {
+            switch (option) {
+            case WEB_CLIENT_VERSION:
+                webClientVersion = (BrowserVersion) option.decode(value);
+                return;
+            default:
+                option.insert(webClientOptions, value);
+                return;
+            }
+        }
+        if (BrowserVersionTrait.fromCapabilityKey(capabilityName) != null) {
+            throw new UnsupportedOperationException(
+                    "Individual browser version traits are immutable; '" + capabilityName + "' cannot be set");
+        }
+        super.setCapability(capabilityName, value);
+    }
+    
+    @Override
+    protected Set<String> getExtraCapabilityNames() {
+        return Collections.singleton(HTMLUNIT_OPTIONS);
+    }
+
+    @Override
+    protected Object getExtraCapability(final String capabilityName) {
+        Require.nonNull("Capability name", capabilityName);
+        if (HTMLUNIT_OPTIONS.equals(capabilityName)) {
+            return exportOptions();
+        }
+        return null;
+    }
+    
+    /**
+     * Import values from the specified source into this <b>HtmlUnitDriver</b> options object.
+     * 
+     * @param source source {@link WebClientOptions} object
+     * @return this {@link HtmlUnitDriverOptions} object
+     */
+    public HtmlUnitDriverOptions importOptions(final WebClientOptions source) {
+        transfer(source, webClientOptions);
+        return this;
+    }
+    
+    /**
+     * Apply values from this <b>HtmlUnitDriver</b> options object to the specifies target.
+     * 
+     * @param target target {@link WebClientOptions} object
+     */
+    public void applyOptions(final WebClientOptions target) {
+        transfer(webClientOptions, target);
+    }
+    
+    public boolean isJavaScriptEnabled() {
+        return webClientOptions.isJavaScriptEnabled();
+    }
+    
+    public HtmlUnitDriverOptions setJavaScriptEnabled(final boolean enableJavascript) {
+        webClientOptions.setJavaScriptEnabled(enableJavascript);
+        return this;
+    }
+    
+    public boolean isDownloadImages() {
+        return webClientOptions.isDownloadImages();
+    }
+    
+    public HtmlUnitDriverOptions setDownloadImages(final boolean downloadImages) {
+        webClientOptions.setDownloadImages(downloadImages);
+        return this;
+    }
+    
+    public BrowserVersion getWebClientVersion() {
+        return webClientVersion;
+    }
+    
+    public HtmlUnitDriverOptions setWebClientVersion(final BrowserVersion webClientVersion) {
+        Require.nonNull("Web client version", webClientVersion);
+        this.webClientVersion = webClientVersion;
+        return this;
+    }
+    
+    public HtmlUnitDriverOptions setSSLClientCertificateKeyStore(final KeyStore keyStore, final char[] keyStorePassword) {
+        webClientOptions.setSSLClientCertificateKeyStore(keyStore, keyStorePassword);
+        return this;
+    }
+
+    public HtmlUnitDriverOptions setSSLClientCertificateKeyStore(final URL keyStoreUrl, final String keyStorePassword,
+            final String keyStoreType) {
+        Require.nonNull("Key store URL", keyStoreUrl);
+        webClientOptions.setSSLClientCertificateKeyStore(keyStoreUrl, keyStorePassword, keyStoreType);
+        return this;
+    }
+
+    public HtmlUnitDriverOptions setSSLClientCertificateKeyStore(final InputStream keyStoreInputStream, final String keyStorePassword,
+            final String keyStoreType) {
+        webClientOptions.setSSLClientCertificateKeyStore(keyStoreInputStream, keyStorePassword, keyStoreType);
+        return this;
+    }
+
+    public HtmlUnitDriverOptions setSSLTrustStore(final URL sslTrustStoreUrl, final String sslTrustStorePassword,
+            final String sslTrustStoreType) {
+        Require.nonNull("Trust store URL", sslTrustStoreUrl);
+        webClientOptions.setSSLTrustStore(sslTrustStoreUrl, sslTrustStorePassword, sslTrustStoreType);
+        return this;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private void importOptions(final Object rawOptions) {
+        Map<String, Object> optionsMap = new HashMap<>();
+        
+        // if value specified
+        if (rawOptions != null) {
+            Require.stateCondition(rawOptions instanceof Map,
+                    "Specified value must be 'Map'; was %s", rawOptions.getClass().getName());
+            optionsMap = (Map<String, Object>) rawOptions;            
+        }
+        
+        // apply specified system properties to options map
+        for (HtmlUnitOption option : HtmlUnitOption.values()) {
+            option.applyPropertyTo(optionsMap);
+        }
+        
+        if (!optionsMap.isEmpty()) {
+            for (HtmlUnitOption option : HtmlUnitOption.values()) {
+                if (optionsMap.containsKey(option.key)) {
+                    switch (option) {
+                    case SSL_CLIENT_CERTIFICATE_PASSWORD:
+                    case SSL_TRUST_STORE_PASSWORD:
+                        continue;
+                    case WEB_CLIENT_VERSION:
+                        webClientVersion = (BrowserVersion) option.decode(optionsMap.get(option.key));
+                        break;
+                    default:
+                        option.insert(webClientOptions, optionsMap.get(option.key));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    
+    private Map<String, Object> exportOptions() {
+        Map<String, Object> optionsMap = new HashMap<>();
+        for (HtmlUnitOption option : HtmlUnitOption.values()) {
+            switch (option) {
+            case SSL_CLIENT_CERTIFICATE_PASSWORD:
+            case SSL_TRUST_STORE_PASSWORD:
+                continue;
+            case WEB_CLIENT_VERSION:
+                if (webClientVersion != null) {
+                    optionsMap.put(option.key, option.encode(webClientVersion));
+                }
+                break;
+            default:
+                Object value = option.obtain(webClientOptions);
+                if (!option.isDefaultValue(value)) {
+                    optionsMap.put(option.key, option.encode(value));
+                }
+                break;
+            }
+        }
+        return optionsMap;
+    }
+    
+    private static void transfer(final WebClientOptions source, final WebClientOptions target) {
+        Require.nonNull("Source capabilities", source);
+        Require.nonNull("Target capabilities", target);        
+        target.setJavaScriptEnabled(source.isJavaScriptEnabled());
+        target.setCssEnabled(source.isCssEnabled());
+        target.setPrintContentOnFailingStatusCode(source.isPrintContentOnFailingStatusCode());
+        target.setThrowExceptionOnFailingStatusCode(source.isThrowExceptionOnFailingStatusCode());
+        target.setThrowExceptionOnScriptError(source.isThrowExceptionOnScriptError());
+        target.setPopupBlockerEnabled(source.isPopupBlockerEnabled());
+        target.setRedirectEnabled(source.isRedirectEnabled());
+        try { target.setTempFileDirectory(source.getTempFileDirectory()); } catch (IOException eaten) { }
+        target.setSSLClientProtocols(source.getSSLClientProtocols());
+        target.setSSLClientCipherSuites(source.getSSLClientCipherSuites());
+        target.setGeolocationEnabled(source.isGeolocationEnabled());
+        target.setDoNotTrackEnabled(source.isDoNotTrackEnabled());
+        target.setHomePage(source.getHomePage());
+        
+        ProxyConfig proxyConfig = source.getProxyConfig();
+        if (proxyConfig != null) {
+            target.setProxyConfig(proxyConfig);
+        }
+        
+        target.setTimeout(source.getTimeout());
+        target.setConnectionTimeToLive(source.getConnectionTimeToLive());
+        target.setUseInsecureSSL(source.isUseInsecureSSL());
+        target.setSSLInsecureProtocol(source.getSSLInsecureProtocol());
+        target.setMaxInMemory(source.getMaxInMemory());
+        target.setHistorySizeLimit(source.getHistorySizeLimit());
+        target.setHistoryPageCacheLimit(source.getHistoryPageCacheLimit());
+        target.setLocalAddress(source.getLocalAddress());
+        target.setDownloadImages(source.isDownloadImages());
+        target.setScreenWidth(source.getScreenWidth());
+        target.setScreenHeight(source.getScreenHeight());
+        target.setWebSocketEnabled(source.isWebSocketEnabled());
+        target.setWebSocketMaxTextMessageSize(source.getWebSocketMaxTextMessageSize());
+        target.setWebSocketMaxTextMessageBufferSize(source.getWebSocketMaxTextMessageBufferSize());
+        target.setWebSocketMaxBinaryMessageSize(source.getWebSocketMaxBinaryMessageSize());
+        target.setWebSocketMaxBinaryMessageBufferSize(source.getWebSocketMaxBinaryMessageBufferSize());
+        target.setFetchPolyfillEnabled(source.isFetchPolyfillEnabled());
+    }
+    
+}

--- a/src/main/java/org/openqa/selenium/htmlunit/options/HtmlUnitOption.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/options/HtmlUnitOption.java
@@ -1,0 +1,992 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.security.KeyStore;
+import java.util.Map;
+
+import org.htmlunit.BrowserVersion;
+import org.htmlunit.Page;
+import org.htmlunit.ProxyConfig;
+import org.htmlunit.WebClientOptions;
+import org.htmlunit.WebConnection;
+
+public enum HtmlUnitOption implements HtmlUnitOptionNames, OptionEnum {
+    WEB_CLIENT_VERSION(optWebClientVersion, BrowserVersion.class, BrowserVersion.BEST_SUPPORTED),
+    
+    /**
+     * Enables/disables JavaScript support.
+     * <p>
+     * property: <b>webdriver.htmlunit.javaScriptEnabled</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code true}
+     */
+    JAVASCRIPT_ENABLED(optJavaScriptEnabled, boolean.class, true) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setJavaScriptEnabled(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isJavaScriptEnabled();
+        }
+    },
+    
+    /**
+     * Enables/disables CSS support.
+     * If disabled, <b>HtmlUnit</b> will not download linked CSS files and also
+     * not trigger the associated {@code onload}/{@code onerror} events.
+     * <p>
+     * property: <b>webdriver.htmlunit.cssEnabled</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code true}
+     */
+    CSS_ENABLED(optCssEnabled, boolean.class, true) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setCssEnabled(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isCssEnabled();
+        }
+    },
+    
+    /**
+     * Specifies whether or not the content of the resulting document will be
+     * printed to the console in the event of a failing response code.
+     * Successful response codes are in the range <b>200-299</b>.
+     * <p>
+     * property: <b>webdriver.htmlunit.printContentOnFailingStatusCode</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code true}
+     */
+    PRINT_CONTENT_ON_FAILING_STATUS_CODE(optPrintContentOnFailingStatusCode, boolean.class, true) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setPrintContentOnFailingStatusCode(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isPrintContentOnFailingStatusCode();
+        }
+    },
+    
+    /**
+     * Specifies whether or not an exception will be thrown in the event of a
+     * failing status code. Successful status codes are in the range <b>200-299</b>.
+     * <p>
+     * property: <b>webdriver.htmlunit.throwExceptionOnFailingStatusCode</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code true}
+     */
+    THROW_EXCEPTION_ON_FAILING_STATUS_CODE(optThrowExceptionOnFailingStatusCode, boolean.class, true) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setThrowExceptionOnFailingStatusCode(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isThrowExceptionOnFailingStatusCode();
+        }
+    },
+    
+    /**
+     * Indicates if an exception should be thrown when a script execution fails
+     * or if it should be caught and just logged to allow page execution to continue.
+     * <p>
+     * property: <b>webdriver.htmlunit.throwExceptionOnScriptError</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code true}
+     */
+    THROW_EXCEPTION_ON_SCRIPT_ERROR(optThrowExceptionOnScriptError, boolean.class, true) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setThrowExceptionOnScriptError(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isThrowExceptionOnScriptError();
+        }
+    },
+    
+    /**
+     * Enable/disable the popup window blocker. By default, the popup blocker is disabled, and popup
+     * windows are allowed. When set to {@code true}, the {@code window.open()} function has no effect
+     * and returns {@code null}.
+     * <p>
+     * property: <b>webdriver.htmlunit.popupBlockerEnabled</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code false}
+     */
+    POPUP_BLOCKER_ENABLED(optPopupBlockerEnabled, boolean.class, false) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setPopupBlockerEnabled(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isPopupBlockerEnabled();
+        }
+    },
+    
+    /**
+     * Sets whether or not redirections will be followed automatically on receipt of a redirect
+     * status code from the server.
+     * <p>
+     * property: <b>webdriver.htmlunit.isRedirectEnabled</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code true} (enable automatic redirection)
+     */
+    IS_REDIRECT_ENABLED(optIsRedirectEnabled, boolean.class, true) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setRedirectEnabled(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isRedirectEnabled();
+        }
+    },
+    
+    /**
+     * Path to the directory to be used for storing the response content in a
+     * temporary file. The specified directory is created if if doesn't exist.
+     * <p>
+     * property: <b>webdriver.htmlunit.tempFileDirectory</b><br>
+     * type: {@link File}<br>
+     * default: {@code null} (use system default)<br>
+     * see: {@link org.htmlunit.WebClientOptions#setMaxInMemory(int) setMaxInMemory}
+     */
+    TEMP_FILE_DIRECTORY(optTempFileDirectory, File.class, null) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            try {
+                options.setTempFileDirectory(TypeCodec.decodeFile(value));
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Failed setting directory for temporary files", e);
+            }
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getTempFileDirectory();
+        }
+    },
+    
+    /**
+     * The SSL client certificate <b>KeyStore</b> to use.
+     * <p>
+     * <b>NOTE</b>: 
+     * <p>
+     * property: <b>webdriver.htmlunit.sslClientCertificateStore</b><br>
+     * type: {@link KeyStore}<br>
+     * default: {@code null}<br>
+     * see: {@link #SSL_CLIENT_CERTIFICATE_TYPE}<br>
+     * see: {@link #SSL_CLIENT_CERTIFICATE_PASSWORD}
+     */
+    SSL_CLIENT_CERTIFICATE_STORE(optSslClientCertificateStore, KeyStore.class, null) {
+        @Override
+        public Object encode(final Object value) {
+            return null;
+        }
+        
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            try {
+                KeyStoreBean bean = TypeCodec.decodeKeyStore(value);
+                options.setSSLClientCertificateKeyStore(bean.createUrl(), bean.getPassword(), bean.getType());
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException(
+                        "Specified SSL_CLIENT_CERTIFICATE_STORE URL is malformed", e);
+            }
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getSSLClientCertificateStore();
+        }
+    },
+    
+    /**
+     * Type of the specified SSL client certificate <b>KeyStore</b> (e.g. - {@code jks} or {@code pkcs12}).
+     * <p>
+     * property: <b>webdriver.htmlunit.sslClientCertificateType</b><br>
+     * type: {@link char[]}<br>
+     * default: {@code null}<br>
+     * see: {@link #SSL_CLIENT_CERTIFICATE_STORE}<br>
+     * see: {@link #SSL_CLIENT_CERTIFICATE_PASSWORD}<br>
+     * see: {@link java.security.Security#getProviders() Security.getProviders()}
+     */
+    SSL_CLIENT_CERTIFICATE_TYPE(optSslClientCertificateType, char[].class, null) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            if (!isDefaultValue(value)) {
+                throw new UnsupportedOperationException(
+                        "SSL client certificate key store type cannot be set as a discrete value; "
+                        + "use HtmlUnitDriverOptions.setSSLClientCertificateStore() instead");
+            }
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            KeyStore keyStore = options.getSSLClientCertificateStore();
+            return (keyStore != null) ? keyStore.getType() : null;
+        }
+    },
+    
+    /**
+     * Password for the specified SSL client certificate <b>KeyStore</b>.
+     * <p>
+     * property: <b>webdriver.htmlunit.sslClientCertificatePassword</b><br>
+     * type: {@code char[]}<br>
+     * default: {@code null}<br>
+     * see: {@link #SSL_CLIENT_CERTIFICATE_STORE}<br>
+     * see: {@link #SSL_CLIENT_CERTIFICATE_TYPE}
+     */
+    SSL_CLIENT_CERTIFICATE_PASSWORD(optSslClientCertificatePassword, char[].class, null) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            if (!isDefaultValue(value)) {
+                throw new UnsupportedOperationException(
+                        "SSL client certificate key store password cannot be set as a discrete value; "
+                        + "use HtmlUnitDriverOptions.setSSLClientCertificateStore() instead");
+            }
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getSSLClientCertificatePassword();
+        }
+    },
+    
+    /**
+     * The SSL server certificate trust store. All server certificates will be validated against
+     * this trust store.
+     * <p>
+     * property: <b>webdriver.htmlunit.sslTrustStore</b><br>
+     * type: {@link KeyStore}<br>
+     * default: {@code null}<br>
+     * see: {@link #SSL_TRUST_STORE_TYPE}<br>
+     * see: {@link #SSL_TRUST_STORE_PASSWORD}
+     */
+    SSL_TRUST_STORE(optSslTrustStore, KeyStore.class, null) {
+        @Override
+        public Object encode(final Object value) {
+            return null;
+        }
+        
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            try {
+                KeyStoreBean bean = TypeCodec.decodeKeyStore(value);
+                options.setSSLTrustStore(bean.createUrl(), bean.getPassword(), bean.getType());
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException(
+                        "Specified SSL_TRUST_STORE URL is malformed", e);
+            }
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getSSLTrustStore();
+        }
+    },
+    
+    /**
+     * Type of the specified SSL trust <b>KeyStore</b> (e.g. - {@code jks} or {@code pkcs12}).
+     * <p>
+     * property: <b>webdriver.htmlunit.sslTrustStoreType</b><br>
+     * type: {@link char[]}<br>
+     * default: {@code null}<br>
+     * see: {@link #SSL_TRUST_STORE}<br>
+     * see: {@link #SSL_TRUST_STORE_PASSWORD}<br>
+     * see: {@link java.security.Security#getProviders() Security.getProviders}
+     */
+    SSL_TRUST_STORE_TYPE(optSslTrustStoreType, char[].class, null) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            if (!isDefaultValue(value)) {
+                throw new UnsupportedOperationException(
+                        "SSL trust key store type cannot be set as a discrete value; "
+                        + "use HtmlUnitDriverOptions.setSSLTrustStore() instead");
+            }
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            KeyStore keyStore = options.getSSLTrustStore();
+            return (keyStore != null) ? keyStore.getType() : null;
+        }
+    },
+    
+    /**
+     * Password for the specified SSL trust <b>KeyStore</b>.
+     * <p>
+     * property: <b>webdriver.htmlunit.sslTrustStorePassword</b><br>
+     * type: {@code char[]}<br>
+     * default: {@code null}<br>
+     * see: {@link #SSL_TRUST_STORE}<br>
+     * see: {@link #SSL_TRUST_STORE_TYPE}
+     */
+    SSL_TRUST_STORE_PASSWORD(optSslTrustStorePassword, char[].class, null) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            if (!isDefaultValue(value)) {
+                throw new UnsupportedOperationException(
+                        "SSL trust key store password cannot be set as a discrete value; "
+                        + "use HtmlUnitDriverOptions.setSSLTrustStore() instead");
+            }
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            throw new UnsupportedOperationException("SSL trust store password cannot be retrieved");
+        }
+    },
+    
+    /**
+     * Sets the protocol versions enabled for use on SSL connections.
+     * <p>
+     * property: <b>webdriver.htmlunit.sslClientProtocols</b><br>
+     * type: {@code String[]}<br>
+     * default: {@code null} (use default protocols)<br>
+     * see: {@link javax.net.ssl.SSLSocket#setEnabledProtocols(String[]) SSLSocket.setEnabledProtocols}
+     */
+    SSL_CLIENT_PROTOCOLS(optSslClientProtocols, String[].class, null) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setSSLClientProtocols(TypeCodec.decodeStringArray(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getSSLClientProtocols();
+        }
+    },
+    
+    /**
+     * Sets the cipher suites enabled for use on SSL connections.
+     * <p>
+     * property: <b>webdriver.htmlunit.sslClientCipherSuites</b><br>
+     * type: {@code String[]}<br>
+     * default: {@code null} (use default cipher suites)<br>
+     * see: {@link javax.net.ssl.SSLSocket#setEnabledCipherSuites(String[]) SSLSocket.setEnabledCipherSuites}
+     */
+    SSL_CLIENT_CIPHER_SUITES(optSslClientCipherSuites, String[].class, null) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setSSLClientCipherSuites(TypeCodec.decodeStringArray(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getSSLClientCipherSuites();
+        }
+    },
+    
+    /**
+     * Enables/disables geo-location support.
+     * <p>
+     * property: <b>webdriver.htmlunit.geolocationEnabled</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code false}
+     */
+    GEOLOCATION_ENABLED(optGeolocationEnabled, boolean.class, false) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setGeolocationEnabled(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isGeolocationEnabled();
+        }
+    },
+    
+    /**
+     * Enables/disables "Do Not Track" support.
+     * <p>
+     * property: <b>webdriver.htmlunit.doNotTrackEnabled</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code false}
+     */
+    DO_NOT_TRACK_ENABLED(optDoNotTrackEnabled, boolean.class, false) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setDoNotTrackEnabled(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isDoNotTrackEnabled();
+        }
+    },
+    
+    /**
+     * Sets the client's home page.
+     * <p>
+     * property: <b>webdriver.htmlunit.homePage</b><br>
+     * type: {@link String}<br>
+     * default: "https://www.htmlunit.org/"
+     */
+    HOME_PAGE(optHomePage, String.class, "https://www.htmlunit.org/") {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setHomePage(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getHomePage();
+        }
+    },
+    
+    /**
+     * Sets the proxy configuration for this client.
+     * <p>
+     * property: <b>webdriver.htmlunit.proxyConfig</b><br>
+     * type: {@link ProxyConfig}<br>
+     * default: {@code null}
+     */
+    PROXY_CONFIG(optProxyConfig, ProxyConfig.class, null) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setProxyConfig(TypeCodec.decodeProxyConfig(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getProxyConfig();
+        }
+    },
+    
+    /**
+     * Sets the timeout of the {@link WebConnection}. Set to zero for an infinite wait.
+     * <p>
+     * <b>NOTE</b>: The timeout is used twice. The first is for making the socket connection, the second is
+     * for data retrieval. If the time is critical you must allow for twice the time specified here.
+     * <p>
+     * property: <b>webdriver.htmlunit.timeout</b><br>
+     * type: {@code int}<br>
+     * default: 90_000 (1.5 minutes in milliseconds)
+     */
+    TIMEOUT(optTimeout, int.class, 90_000) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setTimeout(TypeCodec.decodeInt(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getTimeout();
+        }
+    },
+    
+    /**
+     * Sets the {@code connTimeToLive} (in milliseconds) of the {@link org.apache.http.client.HttpClient HttpClient}
+     * connection pool. Use this if you are working with web pages behind a DNS based load balancer.
+     * <p>
+     * property: <b>webdriver.htmlunit.connectionTimeToLive</b><br>
+     * type: {@code long}<br>
+     * default: -1 (use HTTP default)
+     */
+    CONNECTION_TIME_TO_LIVE(optConnectionTimeToLive, long.class, -1L) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setConnectionTimeToLive(TypeCodec.decodeLong(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getConnectionTimeToLive();
+        }
+    },
+    
+    /**
+     * If set to {@code true}, the client will accept connections to any host, regardless of
+     * whether they have valid certificates or not. This is especially useful when you are trying to
+     * connect to a server with expired or corrupt certificates.
+     * <p>
+     * property: <b>webdriver.htmlunit.useInsecureSSL</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code false}
+     */
+    USE_INSECURE_SSL(optUseInsecureSSL, boolean.class, false) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setUseInsecureSSL(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isUseInsecureSSL();
+        }
+    },
+    
+    /**
+     * Sets the SSL protocol, used only when {@link #USE_INSECURE_SSL} is set to {@code true}.
+     * <p>
+     * property: <b>webdriver.htmlunit.sslInsecureProtocol</b><br>
+     * type: {@link String}<br>
+     * default: {@code null} (use default protocol: SSL)<br>
+     * see: <a href="https://docs.oracle.com/en/java/javase/19/docs/specs/security/standard-names.html#sslcontext-algorithms">
+     * {@code SSLContext} Algorithms</a>
+     */
+    SSL_INSECURE_PROTOCOL(optSslInsecureProtocol, String.class, null) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setSSLInsecureProtocol(TypeCodec.decodeString(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getSSLInsecureProtocol();
+        }
+    },
+    
+    /**
+     * Sets the maximum bytes to have in memory, after which the content is saved to a temporary file.<br>
+     * <b>NOTE</b>: Set this to zero or -1 to deactivate the saving at all.
+     * <p>
+     * property: <b>webdriver.htmlunit.maxInMemory</b><br>
+     * type: {@code int}<br>
+     * default: 500 * 1024
+     */
+    MAX_IN_MEMORY(optMaxInMemory, int.class, 500 * 1024) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setMaxInMemory(TypeCodec.decodeInt(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getMaxInMemory();
+        }
+    },
+    
+    /**
+     * Sets the maximum number of {@link Page pages} to cache in history. <b>HtmlUnit</b>
+     * uses {@code SoftReference<Page>} for storing the pages that are part of the history.
+     * If you like to fine tune this you can use {@link #HISTORY_PAGE_CACHE_LIMIT} to limit
+     * the number of page references stored by the history.
+     * <p>
+     * property: <b>webdriver.htmlunit.historySizeLimit</b><br>
+     * type: {@code int}<br>
+     * default: 50<br>
+     * see: {@link java.lang.ref.SoftReference SoftReference}
+     */
+    HISTORY_SIZE_LIMIT(optHistorySizeLimit, int.class, 50) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setHistorySizeLimit(TypeCodec.decodeInt(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getHistorySizeLimit();
+        }
+    },
+    
+    /**
+     * Sets the maximum number of {@link Page pages} to cache in history. If this value
+     * is smaller than {@link #HISTORY_SIZE_LIMIT}, <b>HtmlUnit</b> will only use soft
+     * references for the first <b>HISTORY_PAGE_CACHE_LIMIT</b> entries in the history.
+     * For older entries, only the URL is saved; the page will be (re)retrieved on demand.
+     * <p>
+     * property: <b>webdriver.htmlunit.historyPageCacheLimit</b><br>
+     * type: {@code int}<br>
+     * default: {@link Integer#MAX_VALUE}
+     */
+    HISTORY_PAGE_CACHE_LIMIT(optHistoryPageCacheLimit, int.class, Integer.MAX_VALUE) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setHistoryPageCacheLimit(TypeCodec.decodeInt(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getHistoryPageCacheLimit();
+        }
+    },
+    
+    /**
+     * Sets the local address to be used for request execution.
+     * <p>
+     * On machines with multiple network interfaces, this parameter can be used to
+     * select the network interface from which the connection originates.
+     * <p>
+     * property: <b>webdriver.htmlunit.localAddress</b><br>
+     * type: {@link InetAddress}<br>
+     * default: {@code null} (use default 'localhost')
+     */
+    LOCAL_ADDRESS(optLocalAddress, InetAddress.class, null) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setLocalAddress(TypeCodec.decodeInetAddress(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getLocalAddress();
+        }
+    },
+    
+    /**
+     * Sets whether or not to automatically download images.
+     * <p>
+     * property: <b>webdriver.htmlunit.downloadImages</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code false}
+     */
+    DOWNLOAD_IMAGES(optDownloadImages, boolean.class, false) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setDownloadImages(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isDownloadImages();
+        }
+    },
+    
+    /**
+     * Sets the screen width.
+     * <p>
+     * property: <b>webdriver.htmlunit.screenWidth</b><br>
+     * type: {@code int}<br>
+     * default: 1920
+     */
+    SCREEN_WIDTH(optScreenWidth, int.class, 1920) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setScreenWidth(TypeCodec.decodeInt(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getScreenWidth();
+        }
+    },
+    
+    /**
+     * Sets the screen height.
+     * <p>
+     * property: <b>webdriver.htmlunit.screenHeight</b><br>
+     * type: {@code int}<br>
+     * default: 1080
+     */
+    SCREEN_HEIGHT(optScreenHeight, int.class, 1080) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setScreenHeight(TypeCodec.decodeInt(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getScreenHeight();
+        }
+    },
+    
+    /**
+     * Enables/disables WebSocket support.
+     * <p>
+     * property: <b>webdriver.htmlunit.webSocketEnabled</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code true}
+     */
+    WEB_SOCKET_ENABLED(optWebSocketEnabled, boolean.class, true) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setWebSocketEnabled(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isWebSocketEnabled();
+        }
+    },
+    
+    /**
+     * Sets the WebSocket {@code maxTextMessageSize}.
+     * <p>
+     * property: <b>webdriver.htmlunit.webSocketMaxTextMessageSize</b><br>
+     * type: {@code int}<br>
+     * default: -1 {use default size)
+     */
+    WEB_SOCKET_MAX_TEXT_MESSAGE_SIZE(optWebSocketMaxTextMessageSize, int.class, -1) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setWebSocketMaxTextMessageSize(TypeCodec.decodeInt(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getWebSocketMaxTextMessageSize();
+        }
+    },
+    
+    /**
+     * Sets the WebSocket {@code maxTextMessageBufferSize}.
+     * <p>
+     * property: <b>webdriver.htmlunit.webSocketMaxTextMessageBufferSize</b><br>
+     * type: {@code int}<br>
+     * default: -1 {use default size)
+     */
+    WEB_SOCKET_MAX_TEXT_MESSAGE_BUFFER_SIZE(optWebSocketMaxTextMessageBufferSize, int.class, -1) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setWebSocketMaxTextMessageBufferSize(TypeCodec.decodeInt(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getWebSocketMaxTextMessageBufferSize();
+        }
+    },
+    
+    /**
+     * Sets the WebSocket {@code maxBinaryMessageSize}.
+     * <p>
+     * property: <b>webdriver.htmlunit.webSocketMaxBinaryMessageSize</b><br>
+     * type: {@code int}<br>
+     * default: -1 {use default size)
+     */
+    WEB_SOCKET_MAX_BINARY_MESSAGE_SIZE(optWebSocketMaxBinaryMessageSize, int.class, -1) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setWebSocketMaxBinaryMessageSize(TypeCodec.decodeInt(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getWebSocketMaxBinaryMessageSize();
+        }
+    },
+    
+    /**
+     * Sets the WebSocket {@code maxBinaryMessageBufferSize}.
+     * <p>
+     * property: <b>webdriver.htmlunit.webSocketMaxBinaryMessageBufferSize</b><br>
+     * type: {@code int}<br>
+     * default: -1 {use default size)
+     */
+    WEB_SOCKET_MAX_BINARY_MESSAGE_BUFFER_SIZE(optWebSocketMaxBinaryMessageBufferSize, int.class, -1) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setWebSocketMaxBinaryMessageBufferSize(TypeCodec.decodeInt(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.getWebSocketMaxBinaryMessageBufferSize();
+        }
+    },
+    
+    /**
+     * Sets whether or not fetch polyfill should be used.
+     * <p>
+     * property: <b>webdriver.htmlunit.fetchPolyfillEnabled</b><br>
+     * type: {@code boolean}<br>
+     * default: {@code false}
+     */
+    FETCH_POLYFILL_ENABLED(optFetchPolyfillEnabled, boolean.class, false) {
+        @Override
+        public void insert(final WebClientOptions options, final Object value) {
+            options.setFetchPolyfillEnabled(TypeCodec.decodeBoolean(value));
+        }
+        
+        @Override
+        public Object obtain(final WebClientOptions options) {
+            return options.isFetchPolyfillEnabled();
+        }
+    };
+    
+    public final String key;
+    public final String name;
+    public final Class<?> type;
+    public final Object initial;
+    
+    HtmlUnitOption(final String key, final Class<?> type, final Object initial) {
+        this.key = key;
+        this.name = "webdriver.htmlunit." + key;
+        this.type = type;
+        this.initial = initial;
+    }
+    
+    @Override
+    public String getCapabilityKey() {
+        return key;
+    }
+    
+    @Override
+    public String getPropertyName() {
+        return name;
+    }
+    
+    @Override
+    public Class<?> getOptionType() {
+        return type;
+    }
+    
+    @Override
+    public Object getDefaultValue() {
+        return initial;
+    }
+    
+    /**
+     * Determine if the specified value matches the default for this option.
+     * 
+     * @param value value to be evaluated
+     * @return {@code true} if specified value matches the default value; otherwise {@code false}
+     */
+    @Override
+    public boolean isDefaultValue(final Object value) {
+        if (initial == null) return value == null;
+        if (value == null) return false;
+        return value.equals(initial);
+    }
+    
+    @Override
+    public
+    void applyPropertyTo(Map<String, Object> optionsMap) {
+        String value = System.getProperty(name);
+        if (value != null) {
+            optionsMap.put(key, decode(value));
+            System.clearProperty(key);
+        }
+    }
+    
+    /**
+     * Encode the specified value according to the type of this option.
+     * 
+     * @param value value to be encoded
+     * @return option-specific encoding for specified value
+     */
+    @Override
+    public Object encode(final Object value) {
+        switch (this.type.getName()) {
+        case "boolean":
+        case "int":
+        case "long":
+        case "java.lang.String":
+        case "[C":
+        case "[Ljava.lang.String;":
+            return value;
+        case "java.io.File":
+            return TypeCodec.encodeFile(value);
+        case "java.net.InetAddress":
+            return TypeCodec.encodeInetAddress(value);
+        case "org.htmlunit.ProxyConfig":
+            return TypeCodec.encodeProxyConfig(value);
+        case "org.htmlunit.BrowserVersion":
+            return TypeCodec.encodeBrowserVersion(value);
+        }
+        throw new IllegalStateException(
+                String.format("Unsupported type '%s' specified for option [%s]; value is of type: %s",
+                this.type.getName(), this.toString(), TypeCodec.getClassName(value)));
+    }
+    
+    /**
+     * Decode the specified value according to the type of this option.
+     * 
+     * @param value value to be decoded
+     * @return option-specific decoding for specified value
+     */
+    @Override
+    public Object decode(final Object value) {
+        switch (this.type.getName()) {
+        case "boolean":
+            return TypeCodec.decodeBoolean(value);
+        case "int":
+            return TypeCodec.decodeInt(value);
+        case "long":
+            return TypeCodec.decodeLong(value);
+        case "java.lang.String":
+            return TypeCodec.decodeString(value);
+        case "[C":
+            return TypeCodec.decodeCharArray(value);
+        case "[Ljava.lang.String;":
+            return TypeCodec.decodeStringArray(value);
+        case "java.io.File":
+            return TypeCodec.decodeFile(value);
+        case "java.net.InetAddress":
+            return TypeCodec.decodeInetAddress(value);
+        case "java.security.KeyStore":
+            return TypeCodec.decodeKeyStore(value);
+        case "org.htmlunit.ProxyConfig":
+            return TypeCodec.decodeProxyConfig(value);
+        case "org.htmlunit.BrowserVersion":
+            return TypeCodec.decodeBrowserVersion(value);
+        }
+        throw new IllegalStateException(
+                String.format("Unsupported type '%s' specified for option [%s]; value is of type: %s",
+                this.type.getName(), this.toString(), TypeCodec.getClassName(value)));
+    }
+    
+    /**
+     * Insert the specified value for this option into the provided web client options object.
+     * 
+     * @param options {@link WebClientOptions} object
+     * @param value value to be inserted
+     */
+    public void insert(final WebClientOptions options, final Object value) {
+        throw new UnsupportedOperationException(
+                String.format("Option '%s' does not support value insertion", this.toString()));
+    }
+    
+    /**
+     * Obtain the value for this option from the specified web client options object.
+     * 
+     * @param options {@link WebClientOptions} object
+     * @return value for this option
+     */
+    public Object obtain(final WebClientOptions options) {
+        return null;
+    }
+    
+    public static HtmlUnitOption fromCapabilityKey(final String key) {
+        for (HtmlUnitOption option : HtmlUnitOption.values()) {
+            if (option.key.equals(key)) {
+                return option;
+            }
+        }
+        return null;
+    }
+    
+    public static HtmlUnitOption fromPropertyName(final String name) {
+        for (HtmlUnitOption option : HtmlUnitOption.values()) {
+            if (option.name.equals(name)) {
+                return option;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/openqa/selenium/htmlunit/options/HtmlUnitOptionNames.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/options/HtmlUnitOptionNames.java
@@ -1,0 +1,60 @@
+//Licensed to the Software Freedom Conservancy (SFC) under one
+//or more contributor license agreements.  See the NOTICE file
+//distributed with this work for additional information
+//regarding copyright ownership.  The SFC licenses this file
+//to you under the Apache License, Version 2.0 (the
+//"License"); you may not use this file except in compliance
+//with the License.  You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing,
+//software distributed under the License is distributed on an
+//"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//KIND, either express or implied.  See the License for the
+//specific language governing permissions and limitations
+//under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+public interface HtmlUnitOptionNames {
+    String SECTION = "htmlunit-option";
+    String optWebClientVersion = "webClientVersion";
+    String optJavaScriptEnabled = "javascriptEnabled";
+    String optCssEnabled = "cssEnabled";
+    String optPrintContentOnFailingStatusCode = "printContentOnFailingStatusCode";
+    String optThrowExceptionOnFailingStatusCode = "throwExceptionOnFailingStatusCode";
+    String optThrowExceptionOnScriptError = "throwExceptionOnScriptError";
+    String optPopupBlockerEnabled = "popupBlockerEnabled";
+    String optIsRedirectEnabled = "isRedirectEnabled";
+    String optTempFileDirectory = "tempFileDirectory";
+    String optSslClientCertificateStore = "sslClientCertificateStore";
+    String optSslClientCertificateType = "sslClientCertificateType";
+    String optSslClientCertificatePassword = "sslClientCertificatePassword";
+    String optSslTrustStore = "sslTrustStore";
+    String optSslTrustStoreType = "sslTrustStoreType";
+    String optSslTrustStorePassword = "sslTrustStorePassword";
+    String optSslClientProtocols = "sslClientProtocols";
+    String optSslClientCipherSuites = "sslClientCipherSuites";
+    String optGeolocationEnabled = "geolocationEnabled";
+    String optDoNotTrackEnabled = "doNotTrackEnabled";
+    String optHomePage = "homePage";
+    String optProxyConfig = "proxyConfig";
+    String optTimeout = "timeout";
+    String optConnectionTimeToLive = "connectionTimeToLive";
+    String optUseInsecureSSL = "useInsecureSSL";
+    String optSslInsecureProtocol = "sslInsecureProtocol";
+    String optMaxInMemory = "maxInMemory";
+    String optHistorySizeLimit = "historySizeLimit";
+    String optHistoryPageCacheLimit = "historyPageCacheLimit";
+    String optLocalAddress = "localAddress";
+    String optDownloadImages = "downloadImages";
+    String optScreenWidth = "screenWidth";
+    String optScreenHeight = "screenHeight";
+    String optWebSocketEnabled = "webSocketEnabled";
+    String optWebSocketMaxTextMessageSize = "webSocketMaxTextMessageSize";
+    String optWebSocketMaxTextMessageBufferSize = "webSocketMaxTextMessageBufferSize";
+    String optWebSocketMaxBinaryMessageSize = "webSocketMaxBinaryMessageSize";
+    String optWebSocketMaxBinaryMessageBufferSize = "webSocketMaxBinaryMessageBufferSize";
+    String optFetchPolyfillEnabled = "fetchPolyfillEnabled";
+}

--- a/src/main/java/org/openqa/selenium/htmlunit/options/KeyStoreBean.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/options/KeyStoreBean.java
@@ -1,0 +1,57 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import java.io.Serializable;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@SuppressWarnings("serial")
+public class KeyStoreBean implements Serializable {
+    private String url;
+    private String password;
+    private String type;
+    
+    public String getUrl() {
+        return url;
+    }
+    
+    public void setUrl(final String url) {
+       this.url = url; 
+    }
+    
+    public String getPassword() {
+        return password;
+    }
+    
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(final String type) {
+        this.type = type;
+    }
+    
+    public URL createUrl() throws MalformedURLException {
+        return new URL(url);
+    }
+}

--- a/src/main/java/org/openqa/selenium/htmlunit/options/OptionEnum.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/options/OptionEnum.java
@@ -1,0 +1,31 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import java.util.Map;
+
+public interface OptionEnum {
+    String getCapabilityKey();
+    String getPropertyName();
+    Class<?> getOptionType();
+    Object getDefaultValue();
+    boolean isDefaultValue(Object value);
+    void applyPropertyTo(Map<String, Object> optionsMap);
+    Object encode(Object value);
+    Object decode(Object value);
+}

--- a/src/main/java/org/openqa/selenium/htmlunit/options/ProxyConfigBean.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/options/ProxyConfigBean.java
@@ -1,0 +1,130 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.htmlunit.ProxyConfig;
+
+@SuppressWarnings("serial")
+public class ProxyConfigBean implements Serializable {
+    private String host;
+    private int port;
+    private String scheme;
+    private boolean socksProxy;
+    private List<String> bypassHosts;
+    private String autoConfigUrl;
+    
+    public String getHost() {
+        return host;
+    }
+    
+    public void setHost(final String host) {
+        this.host = host;
+    }
+    
+    public int getPort() {
+        return port;
+    }
+    
+    public void setPort(final int port) {
+        this.port = port;
+    }
+    
+    public String getScheme() {
+        return scheme;
+    }
+    
+    public void setScheme(final String scheme) {
+        this.scheme = scheme;
+    }
+    
+    public boolean isSocksProxy() {
+        return socksProxy;
+    }
+    
+    public void setSocksProxy(final boolean socksProxy) {
+        this.socksProxy = socksProxy;
+    }
+    
+    public List<String> getBypassHosts() {
+        return bypassHosts;
+    }
+    
+    public String getBypassHosts(final int index) {
+        return bypassHosts.get(index);
+    }
+
+    public void setBypassHosts(final List<String> bypassHosts) {
+        this.bypassHosts = bypassHosts;
+    }
+    
+    public void setBypassHosts(final int index, final String bypassHost) {
+        bypassHosts.set(index, bypassHost);
+    }
+    
+    public String getAutoConfigUrl() {
+        return autoConfigUrl;
+    }
+    
+    public void setAutoConfigUrl(final String autoConfigUrl) {
+        this.autoConfigUrl = autoConfigUrl;
+    }
+    
+    /**
+     * Encode the specified {@code ProxyConfig} object.
+     * 
+     * @param value {@link ProxyConfig} object to be encoded
+     * @return encoded {@code ProxyConfig} object
+     */
+    public static Map<String, Object> encodeProxyConfig(final ProxyConfig value) {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("host", value.getProxyHost());
+        configMap.put("port", value.getProxyPort());
+        configMap.put("scheme", value.getProxyScheme());
+        configMap.put("bypassHosts", getBypassHosts(value));
+        configMap.put("autoConfigUrl", value.getProxyAutoConfigUrl());
+        return configMap;
+    }
+    
+    public ProxyConfig build() {
+        ProxyConfig value = new ProxyConfig(host, port, scheme, socksProxy);
+        bypassHosts.forEach(value::addHostsToProxyBypass);
+        value.setProxyAutoConfigUrl(autoConfigUrl);
+        return value;
+    }
+    
+    @SuppressWarnings("unchecked")
+    static List<String> getBypassHosts(final ProxyConfig value) {
+        try {
+            Field proxyBypassHosts_ = ProxyConfig.class.getDeclaredField("proxyBypassHosts_");
+            proxyBypassHosts_.setAccessible(true);
+            Map<String, Pattern> proxyBypassHosts = (Map<String, Pattern>) proxyBypassHosts_.get(value);
+            return new ArrayList<String>(proxyBypassHosts.keySet());
+        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+            return null;
+        }
+        
+    }
+}

--- a/src/main/java/org/openqa/selenium/htmlunit/options/TypeCodec.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/options/TypeCodec.java
@@ -1,0 +1,429 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TimeZone;
+
+import org.htmlunit.BrowserVersion;
+import org.htmlunit.ProxyConfig;
+import org.htmlunit.BrowserVersion.BrowserVersionBuilder;
+import org.openqa.selenium.json.Json;
+import org.openqa.selenium.json.TypeToken;
+
+class TypeCodec {
+    
+    private TypeCodec() {
+        throw new AssertionError("TypeCodec is a static utility class that cannot be instantiated");
+    }
+    
+    /** Specifier for {@code Map<String, Object>} input/output type */
+    private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() {}.getType();
+    
+    /** Specifier for {@code List<String>} input/output type */
+    private static final Type LIST_TYPE = new TypeToken<List<String>>() {}.getType();
+    
+    /**
+     * Decode the specified value as a {@code boolean}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@code boolean}
+     */
+    static boolean decodeBoolean(final Object value) {
+        if (value instanceof Boolean) {
+            return ((Boolean) value).booleanValue();
+        }
+        if (value instanceof String) {
+            return Boolean.parseBoolean((String) value);
+        }
+        throw new IllegalStateException("Specified value must be 'Boolean' or 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Decode the specified value as an {@code int}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@code int}
+     */
+    static int decodeInt(final Object value) {
+        if (value instanceof Long) {
+            return ((Long) value).intValue();
+        }
+        if (value instanceof Integer) {
+            return ((Integer) value).intValue();
+        }
+        if (value instanceof String) {
+            return Integer.parseInt((String) value);
+        }
+        throw new IllegalStateException("Specified value must be 'Long', 'Integer', or 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Decode the specified value as a {@code long}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@code long}
+     */
+    static long decodeLong(final Object value) {
+        if (value instanceof Long) {
+            return ((Long) value).longValue();
+        }
+        if (value instanceof String) {
+            return Long.parseLong((String) value);
+        }
+        throw new IllegalStateException("Specified value must be 'Long' or 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Decode the specified value as a {@code String}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@link String}
+     */
+    static String decodeString(final Object value) {
+        if (value == null) return null;
+        if (value instanceof String) {
+            return (String) value;
+        }
+        throw new IllegalStateException("Specified value must be 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Decode the specified value as a {@code char[]}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@code char[]}
+     */
+    static char[] decodeCharArray(final Object value) {
+        if (value == null) return null;
+        if (value instanceof char[]) {
+            return (char[]) value;
+        }
+        if (value instanceof String) {
+            return ((String) value).toCharArray();
+        }
+        throw new IllegalStateException("Specified value must be 'char[]' or 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Decode the specified value as a {@code String[]}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@link String}[]
+     */
+    static String[] decodeStringArray(final Object value) {
+        if (value == null) return null;
+        if (value instanceof String[]) {
+            return (String[]) value;
+        }
+        if (value instanceof String) {
+            List<String> listOfStrings = new Json().toType((String) value, LIST_TYPE);
+            return listOfStrings.toArray(new String[0]);
+        }
+        throw new IllegalStateException("Specified value must be 'String[]' or 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Encode the specified {@code File} object.
+     * 
+     * @param value {@link File} object to be encoded
+     * @return encoded {@code File} object
+     */
+    static String encodeFile(final Object value) {
+        if (value instanceof String) {
+            return (String) value;
+        }
+        if (value instanceof File) {
+            try {
+                return ((File) value).getCanonicalPath();
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed encoding 'File' to canonical path", e);
+            }
+        }
+        throw new IllegalStateException("Specified value must be 'File' or 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Decode the specified value as a {@code File}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@link File}
+     */
+    static File decodeFile(final Object value) {
+        if (value instanceof File) {
+            return (File) value;
+        }
+        if (value instanceof String) {
+            return new File((String) value);
+        }
+        throw new IllegalStateException("Specified value must be 'File' or 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Encode the specified {@code InetAddress} object.
+     * 
+     * @param value {@link InetAddress} object to be encoded
+     * @return encoded {@code InetAddress} object
+     */
+    static String encodeInetAddress(final Object value) {
+        if (value instanceof String) {
+            return (String) value;
+        }
+        if (value instanceof InetAddress) {
+            return ((InetAddress) value).getHostAddress();
+        }
+        throw new IllegalStateException("Specified value must be 'InetAddress' or 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Decode the specified value as an {@code InetAddress}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@link InetAddress}
+     */
+    static InetAddress decodeInetAddress(final Object value) {
+        if (value instanceof InetAddress) {
+            return (InetAddress) value;
+        }
+        if (value instanceof String) {
+            try {
+                return InetAddress.getByName((String) value);
+            } catch (UnknownHostException e) {
+                throw new IllegalArgumentException("Failed decoding address: " + ((String) value), e);
+            }
+        }
+        throw new IllegalStateException("Specified value must be 'InetAddress' or 'String'; was " + getClassName(value));
+    }
+    
+    static KeyStoreBean decodeKeyStore(final Object value) {
+        if (value instanceof String) {
+            KeyStoreBean bean = new Json().toType((String) value, KeyStoreBean.class);
+            Objects.requireNonNull(bean.getUrl(), "Client certificate store object omits [url] property");
+            Objects.requireNonNull(bean.getType(), "Client certificate store object omits [type] property");
+            return bean;
+        }
+        
+        throw new IllegalStateException("Specified value must be 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Encode the specified {@code ProxyConfig} object.
+     * 
+     * @param value {@link ProxyConfig} object to be encoded
+     * @return encoded {@code ProxyConfig} object
+     */
+    static Map<String, Object> encodeProxyConfig(final Object value) {
+        if (value instanceof ProxyConfig) {
+            return ProxyConfigBean.encodeProxyConfig((ProxyConfig) value);
+        }
+        throw new IllegalStateException("Specified value must be 'ProxyConfig'; was " + getClassName(value));
+    }
+    
+    /**
+     * Decode the specified value as a {@code ProxyConfig}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@link ProxyConfig}
+     */
+    @SuppressWarnings("unchecked")
+    static ProxyConfig decodeProxyConfig(final Object value) {
+        String json;
+
+        if (value instanceof ProxyConfig) {
+            return (ProxyConfig) value;
+        } else if (value instanceof Map) {
+            json = new Json().toJson((Map<String, Object>) value);
+        } else if (value instanceof String) {
+            json = (String) value;
+        } else {
+            throw new IllegalStateException("Specified value must be 'ProxyConfig', 'Map', or 'String'; was " + getClassName(value));
+        }
+        
+        ProxyConfigBean bean = new Json().toType(json, ProxyConfigBean.class);
+        return bean.build();
+    }
+
+    /**
+     * Encode the specified {@code BrowserVersion} object.
+     * 
+     * @param value {@link BrowserVersion} object to be encoded
+     * @return encoded {@code BrowserVersion} object
+     */
+    static Map<String, Object> encodeBrowserVersion(final Object value) {
+        if (value instanceof BrowserVersion) {
+            Map<String, Object> optionsMap = new HashMap<>();
+            BrowserVersion browserVersion = (BrowserVersion) value;
+            for (BrowserVersionTrait trait : BrowserVersionTrait.values()) {
+                Object traitValue = trait.obtain(browserVersion);
+                if (!trait.isDefaultValue(traitValue)) {
+                    optionsMap.put(trait.key, trait.encode(traitValue));
+                }
+            }
+            return optionsMap;
+        }
+        throw new IllegalStateException("Specified value must be 'BrowserVersion'; was " + getClassName(value));
+    }
+    
+    /**
+     * Decode the specified value as a {@code BrowserVersion}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@link BrowserVersion}
+     */
+    @SuppressWarnings({ "unchecked" })
+    static BrowserVersion decodeBrowserVersion(final Object value) {
+        int code;
+        String name;
+        BrowserVersion seed;
+        Map<String, Object> optionsMap = new HashMap<>();
+        
+        // if value spec'd
+        if (value != null) {
+            if (value instanceof BrowserVersion) {
+                // encode BrowserVersion to options map
+                optionsMap = encodeBrowserVersion(value);
+            } else if (value instanceof Map) {
+                // adopt specified options map
+                optionsMap = (Map<String, Object>) value;
+            } else if (value instanceof String) {
+                // decode JSON value to options map
+                optionsMap = new Json().toType((String) value, MAP_TYPE);
+            } else {
+                throw new IllegalStateException("Specified value must be 'BrowserVersion', 'Map', or 'String'; was " + getClassName(value));
+            }
+        }
+        
+        // apply specified system properties to options map
+        for (BrowserVersionTrait option : BrowserVersionTrait.values()) {
+            option.applyPropertyTo(optionsMap);
+        }
+        
+        // browser version numeric code is required
+        Object numericCode =  Objects.requireNonNull(optionsMap.get(BrowserVersionTrait.NUMERIC_CODE.key),
+                "Required browser version trait [numericCode] is unspecified");
+        
+        if (numericCode instanceof Long) {
+            code = ((Long) numericCode).intValue();
+        } else if (numericCode instanceof Integer) {
+            code = ((Integer) numericCode).intValue();
+        } else {
+            throw new IllegalStateException("Browser numeric code must be 'Long' or 'Integer'; was " + getClassName(numericCode));
+        }
+        
+        // browser version nickname is required
+        Object nickname = Objects.requireNonNull(optionsMap.get(BrowserVersionTrait.NICKNAME.key),
+                "Required browser version trait [nickname] is unspecified");
+        
+        if (nickname instanceof String) {
+            name = (String) nickname;
+        } else {
+            throw new IllegalStateException("Browser nickname must be 'String'; was " + getClassName(nickname));
+        }
+        
+        // create seed from spec'd name
+        if (name.startsWith("Chrome")) {
+            seed = BrowserVersion.CHROME;
+        } else if (name.startsWith("Edge")) {
+            seed = BrowserVersion.EDGE;
+        } else if (name.startsWith("FF")) {
+            seed = (code == 115) ? BrowserVersion.FIREFOX_ESR : BrowserVersion.FIREFOX;
+        } else {
+            throw new IllegalArgumentException("Browser nickname must start with 'Chrome', 'Edge', or 'FF'; was: " + name);
+        }
+            
+        // if spec'd numeric code overrides seed
+        if (seed.getBrowserVersionNumeric() != code) {
+            try {
+                Field browserVersionNumeric_ = BrowserVersion.class.getField("browserVersionNumeric_");
+                browserVersionNumeric_.setAccessible(true);
+                browserVersionNumeric_.set(seed, code);
+            } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+                // nothing to do here
+            }
+        }
+        
+        // create browser version builder from seed
+        BrowserVersionBuilder builder = new BrowserVersionBuilder(seed);
+        
+        // apply defined options map values to browser version builder
+        for (BrowserVersionTrait trait : BrowserVersionTrait.values()) {
+            switch (trait) {
+            case NUMERIC_CODE:
+            case NICKNAME:
+                continue;
+            default:
+                if (optionsMap.containsKey(trait.key)) {
+                    trait.apply(optionsMap.get(trait.key), builder);
+                }
+            }
+        }
+        
+        return builder.build();
+    }
+    
+    /**
+     * Encode the specified time zone object.
+     * 
+     * @param value {@link TimeZone} object to be encoded
+     * @return encoded {@code TimeZone} object
+     */
+    static String encodeTimeZone(final Object value) {
+        if (value instanceof String) {
+            return (String) value;
+        }
+        if (value instanceof TimeZone) {
+            return ((TimeZone) value).getID();
+        }
+        throw new IllegalStateException("Specified value must be 'TimeZone' or 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Decode the specified value as a {@code TimeZone}.
+     * 
+     * @param value value to be decoded
+     * @return specified value decoded as {@link TimeZone}
+     */
+    static TimeZone decodeTimeZone(final Object value) {
+        if (value instanceof TimeZone) {
+            return (TimeZone) value;
+        }
+        if (value instanceof String) {
+            return TimeZone.getTimeZone((String) value);
+        }
+        throw new IllegalStateException("Specified value must be 'TimeZone' or 'String'; was " + getClassName(value));
+    }
+    
+    /**
+     * Get class name for the specified value.
+     * 
+     * @param value value from which to get class name
+     * @return class name for specified value; 'null' if value is {@code null}
+     */
+    static String getClassName(final Object value) {
+        return (value != null) ? value.getClass().getName() : "'null'";
+    }
+}

--- a/src/main/java/org/openqa/selenium/htmlunit/w3/Algorithms.java
+++ b/src/main/java/org/openqa/selenium/htmlunit/w3/Algorithms.java
@@ -50,7 +50,7 @@ public final class Algorithms {
      * @return actions by tick
      */
     public static List<List<Action>> extractActionSequence(
-            final Collection<Sequence> sequences /* InputState inputState, paramters */) {
+            final Collection<Sequence> sequences /* InputState inputState, parameters */) {
 
         // Let actions by tick be an empty List.
         final List<List<Action>> actionsByTick = new ArrayList<>();
@@ -335,6 +335,7 @@ public final class Algorithms {
      *      wheel action</a>
      */
     private static Action processWheelAction(final String id, final Map<String, Object> actionItem) {
+        // TODO: Implement this function
         return null;
     }
 
@@ -447,6 +448,7 @@ public final class Algorithms {
      *      a pointer move action</a>
      */
     private static void processPointerMoveAction(final Map<String, Object> actionItem, final Action action) {
+        // TODO: Implement this function
     }
 
     /**
@@ -455,6 +457,7 @@ public final class Algorithms {
      *      a pointer cancel action</a>
      */
     private static void processPointerCancelAction(final Map<String, Object> actionItem) {
+        // TODO: Implement this function
     }
 
     /**

--- a/src/test/java/org/openqa/selenium/htmlunit/HtmlUnitDriverTest.java
+++ b/src/test/java/org/openqa/selenium/htmlunit/HtmlUnitDriverTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.htmlunit.options.HtmlUnitDriverOptions;
 import org.openqa.selenium.remote.Browser;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -515,6 +516,25 @@ public class HtmlUnitDriverTest {
                 assertFalse("client.getOptions().isJavaScriptEnabled() is true",
                         client.getOptions().isJavaScriptEnabled());
                 assertFalse("client.isJavaScriptEnabled() is true", client.isJavaScriptEnabled());
+                assertTrue("client.isJavaScriptEngineEnabled() is false", client.isJavaScriptEngineEnabled());
+
+                return client;
+            }
+        };
+    }
+    
+    @Test
+    public void ctorHtmlUnitDriverOptions() {
+        final HtmlUnitDriverOptions capabilities = new HtmlUnitDriverOptions();
+        
+        new HtmlUnitDriver(capabilities) {
+            @Override
+            protected WebClient modifyWebClient(final WebClient client) {
+                assertEquals(BrowserVersion.getDefault(), client.getBrowserVersion());
+
+                assertTrue("client.getOptions().isJavaScriptEnabled() is false",
+                        client.getOptions().isJavaScriptEnabled());
+                assertTrue("client.isJavaScriptEnabled() is false", client.isJavaScriptEnabled());
                 assertTrue("client.isJavaScriptEngineEnabled() is false", client.isJavaScriptEngineEnabled());
 
                 return client;

--- a/src/test/java/org/openqa/selenium/htmlunit/options/BeanTest.java
+++ b/src/test/java/org/openqa/selenium/htmlunit/options/BeanTest.java
@@ -1,0 +1,68 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import org.htmlunit.ProxyConfig;
+import org.junit.Test;
+import org.openqa.selenium.json.Json;
+
+public class BeanTest {
+    
+    private static final String proxyConfig = 
+            "{\"host\": \"proxy.example.com\", \"port\": 8080, \"scheme\": \"https\", "
+            + "\"socksProxy\": false, \"bypassHosts\": [\"localhost\", \"intranet.info\"], "
+            + "\"autoConfigUrl\": \"http://aaa/bb.pac\"}";
+    
+    private static final String keyStore =
+            "{\"url\":\"file:///path/to/cert/store\", \"password\":\"fortnight\", \"type\":\"jks\"}";
+    
+    @Test
+    public void decodeProxyConfigBean() {
+        ProxyConfigBean bean = new Json().toType(proxyConfig, ProxyConfigBean.class);
+        assertEquals("Failed decoding [host]", "proxy.example.com", bean.getHost());
+        assertEquals("Failed decoding [port]", 8080, bean.getPort());
+        assertEquals("Failed decoding [scheme]", "https", bean.getScheme());
+        assertEquals("Failed decoding [socksProxy]", false, bean.isSocksProxy());
+        assertEquals("Failed decoding [bypassHosts]", Arrays.asList("localhost", "intranet.info"), bean.getBypassHosts());
+        assertEquals("Failed decoding [autoConfigUrl]", "http://aaa/bb.pac", bean.getAutoConfigUrl());
+        
+        ProxyConfig config = bean.build();
+        assertEquals("Failed building [host]", "proxy.example.com", config.getProxyHost());
+        assertEquals("Failed building [port]", 8080, config.getProxyPort());
+        assertEquals("Failed building [scheme]", "https", config.getProxyScheme());
+        assertEquals("Failed building [socksProxy]", false, config.isSocksProxy());
+        assertEquals("Failed decoding [bypassHosts]", Arrays.asList("localhost", "intranet.info"), ProxyConfigBean.getBypassHosts(config));
+        assertEquals("Failed building [autoConfigUrl]", "http://aaa/bb.pac", config.getProxyAutoConfigUrl());
+    }
+    
+    @Test
+    public void decodeKeyStoreBean() throws MalformedURLException {
+        KeyStoreBean bean = new Json().toType(keyStore, KeyStoreBean.class);
+        assertEquals("Failed decoding [url]", "file:///path/to/cert/store", bean.getUrl());
+        assertEquals("failed deciding [password]", "fortnight", bean.getPassword());
+        assertEquals("Failed decoding [type]", "jks", bean.getType());
+        
+        assertEquals("Failed creating URL from [url]", new URL("file:///path/to/cert/store"), bean.createUrl());
+    }
+    
+}

--- a/src/test/java/org/openqa/selenium/htmlunit/options/BrowserVersionTraitTest.java
+++ b/src/test/java/org/openqa/selenium/htmlunit/options/BrowserVersionTraitTest.java
@@ -1,0 +1,43 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import static org.junit.Assert.assertEquals;
+import static org.openqa.selenium.htmlunit.options.BrowserVersionTrait.*;
+
+import java.util.TimeZone;
+
+import org.htmlunit.BrowserVersion;
+import org.junit.Test;
+
+public class BrowserVersionTraitTest {
+    
+    @Test
+    public void encodeAndDecodeTimeZone() {
+        TimeZone timeZone = TimeZone.getTimeZone("America/New_York");
+        Object encoded = SYSTEM_TIMEZONE.encode(timeZone);
+        TimeZone decoded = (TimeZone) SYSTEM_TIMEZONE.decode(encoded);
+        assertEquals(timeZone, decoded);
+    }
+    
+    static void verify(final BrowserVersion expect, final BrowserVersion actual) {
+        for (BrowserVersionTrait trait : BrowserVersionTrait.values()) {
+            assertEquals("Browser version trait mismatch for: " + trait.key, trait.obtain(expect), trait.obtain(actual));
+        }
+    }
+}

--- a/src/test/java/org/openqa/selenium/htmlunit/options/HtmlUnitDriverOptionsTest.java
+++ b/src/test/java/org/openqa/selenium/htmlunit/options/HtmlUnitDriverOptionsTest.java
@@ -1,0 +1,130 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import static org.junit.Assert.assertEquals;
+import static org.openqa.selenium.htmlunit.options.HtmlUnitOption.*;
+import static org.openqa.selenium.htmlunit.options.BrowserVersionTrait.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+
+import org.htmlunit.BrowserVersion;
+import org.htmlunit.util.UrlUtils;
+import org.junit.Test;
+import org.openqa.selenium.remote.Browser;
+
+/**
+ * HtmlUnitDriverOptions tests.
+ *
+ * @author Scott Babcock
+ */
+public class HtmlUnitDriverOptionsTest {
+    
+    @Test
+    public void newOptionsWithoutArguments() {
+        HtmlUnitDriverOptions options = new HtmlUnitDriverOptions();
+        verifyOptions(options, BrowserVersion.BEST_SUPPORTED);
+    }
+
+    @Test
+    public void newOptionsWithChromeVersion() {
+        HtmlUnitDriverOptions options = new HtmlUnitDriverOptions(BrowserVersion.CHROME);
+        verifyOptions(options, BrowserVersion.CHROME);
+    }
+
+    @Test
+    public void newOptionsWithEdgeVersion() {
+        HtmlUnitDriverOptions options = new HtmlUnitDriverOptions(BrowserVersion.EDGE);
+        verifyOptions(options, BrowserVersion.EDGE);
+    }
+
+    @Test
+    public void newOptionsWithFirefoxVersion() {
+        HtmlUnitDriverOptions options = new HtmlUnitDriverOptions(BrowserVersion.FIREFOX);
+        verifyOptions(options, BrowserVersion.FIREFOX);
+    }
+
+    @Test
+    public void newOptionsWithFirefoxESRVersion() {
+        HtmlUnitDriverOptions options = new HtmlUnitDriverOptions(BrowserVersion.FIREFOX_ESR);
+        verifyOptions(options, BrowserVersion.FIREFOX_ESR);
+    }
+
+    @Test
+    public void verifyEncodeAndDecode() {
+        HtmlUnitDriverOptions options = new HtmlUnitDriverOptions();
+        Map<String, Object> optionsMap = options.asMap();
+        HtmlUnitDriverOptions decoded = new HtmlUnitDriverOptions(optionsMap);
+        assertEquals("Options object serialize/deserialize mismatch", options, decoded);
+    }
+    
+    @Test
+    public void verifyFirefoxESRBrowserVersion() {
+        HtmlUnitDriverOptions options = new HtmlUnitDriverOptions(BrowserVersion.FIREFOX_ESR);
+        BrowserVersion browserVersion = (BrowserVersion) options.getCapability(optWebClientVersion);
+        assertEquals("Browser version mismatch", BrowserVersion.FIREFOX_ESR, browserVersion);
+    }
+    
+    @Test
+    public void verifyEuropeBerlinTimeZone() {
+        // NOTE: Don't follow this convoluted process to set the system time zone!
+        //       This test is verifying encode/decode of BrowserVersion and HtmlUnitDriverOptions.
+        Map<String, Object> encoded = TypeCodec.encodeBrowserVersion(BrowserVersion.BEST_SUPPORTED);
+        encoded.put(optSystemTimezone, "Europe/Berlin");
+        HtmlUnitDriverOptions options = new HtmlUnitDriverOptions();
+        options.setCapability(optWebClientVersion, encoded);
+        TimeZone timeZone = (TimeZone) options.getCapability(optSystemTimezone);
+        assertEquals("Time zone mismatch", "Europe/Berlin", timeZone.getID());
+    }
+
+    private void verifyOptions(final HtmlUnitDriverOptions options, final BrowserVersion browserVersion) {
+        assertEquals("Browser name mismatch", Browser.HTMLUNIT.browserName(), options.getBrowserName());
+        BrowserVersionTraitTest.verify(browserVersion, options.getWebClientVersion());
+
+        Map<HtmlUnitOption, Object> nonDefault = getNonDefaultOptions(options);
+        Set<HtmlUnitOption> expectKeySet = Set.of(WEB_CLIENT_VERSION, HOME_PAGE, PRINT_CONTENT_ON_FAILING_STATUS_CODE,
+                THROW_EXCEPTION_ON_FAILING_STATUS_CODE, USE_INSECURE_SSL);
+
+        assertEquals("Non-default value set mismatch", expectKeySet, nonDefault.keySet());
+
+        BrowserVersion decodedVersion = (BrowserVersion) WEB_CLIENT_VERSION.decode(nonDefault.get(WEB_CLIENT_VERSION));
+        BrowserVersionTraitTest.verify(browserVersion, decodedVersion);
+
+        assertEquals("Mismatch for option: homePage", UrlUtils.URL_ABOUT_BLANK.toString(), nonDefault.get(HOME_PAGE));
+        assertEquals("Mismatch for option: printContentOnFailingStatusCode", false,
+                nonDefault.get(PRINT_CONTENT_ON_FAILING_STATUS_CODE));
+        assertEquals("Mismatch for option: throwExceptionOnFailingStatusCode", false,
+                nonDefault.get(THROW_EXCEPTION_ON_FAILING_STATUS_CODE));
+        assertEquals("Mismatch for option: useInsecureSSL", true, nonDefault.get(USE_INSECURE_SSL));
+    }
+    
+    @SuppressWarnings("unchecked")
+    private static Map<HtmlUnitOption, Object> getNonDefaultOptions(final HtmlUnitDriverOptions options) {
+        Map<HtmlUnitOption, Object> result = new HashMap<>();
+        Map<String, Object> extraOptions = (Map<String, Object>) options.getExtraCapability(HtmlUnitDriverOptions.HTMLUNIT_OPTIONS);
+        for (HtmlUnitOption option : HtmlUnitOption.values()) {
+            if (extraOptions.containsKey(option.key)) {
+                result.put(option, extraOptions.get(option.key));
+            }
+        }
+        return result;
+    }
+}

--- a/src/test/java/org/openqa/selenium/htmlunit/options/HtmlUnitOptionTest.java
+++ b/src/test/java/org/openqa/selenium/htmlunit/options/HtmlUnitOptionTest.java
@@ -1,0 +1,95 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.htmlunit.options;
+
+import static org.junit.Assert.assertEquals;
+import static org.openqa.selenium.htmlunit.options.HtmlUnitOption.*;
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.File;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import org.htmlunit.BrowserVersion;
+import org.htmlunit.ProxyConfig;
+import org.junit.Test;
+
+public class HtmlUnitOptionTest {
+    
+    @Test
+    public void decodeStringToCharArray() {
+        char[] sslTrustStoreType = "jks".toCharArray();
+        char[] decoded = (char[]) SSL_TRUST_STORE_TYPE.decode("jks");
+        assertArrayEquals(sslTrustStoreType, decoded);
+    }
+    
+    @Test
+    public void decodeStringToStringArray() {
+        String[] sslClientProtocols = new String[] {"foo", "bar", "baz"};
+        String encoded = "[\"foo\", \"bar\",\"baz\"]";
+        String[] decoded = (String[]) SSL_CLIENT_PROTOCOLS.decode(encoded);
+        assertArrayEquals(sslClientProtocols, decoded);
+    }
+    
+    @Test
+    public void encodeAndDecodeFile() {
+        File tempFileDirectory = new File(System.getProperty("user.home"));
+        String encoded = (String) TEMP_FILE_DIRECTORY.encode(tempFileDirectory);
+        File decoded = (File) TEMP_FILE_DIRECTORY.decode(encoded);
+        assertEquals(tempFileDirectory, decoded);
+    }
+    
+    @Test
+    public void encodeAndDecodeInetAddress() throws UnknownHostException {
+        final InetAddress localHost = InetAddress.getLocalHost();
+        String encoded = (String) LOCAL_ADDRESS.encode(localHost);
+        InetAddress decoded = (InetAddress) LOCAL_ADDRESS.decode(encoded);
+        assertEquals(localHost, decoded);
+    }
+    
+    @Test
+    public void encodeAndDecodeProxyConfig() {
+        final ProxyConfig proxyConfig = new ProxyConfig();
+        proxyConfig.setProxyPort("http");
+        proxyConfig.setProxyHost("htmlunit.proxy");
+        proxyConfig.setProxyPort(1234);
+        proxyConfig.addHostsToProxyBypass("localhost");
+        proxyConfig.addHostsToProxyBypass("127\\.0\\.0\\.1");
+        Object encoded = PROXY_CONFIG.encode(proxyConfig);
+        ProxyConfig decoded = (ProxyConfig) PROXY_CONFIG.decode(encoded);
+        verifyEquals(proxyConfig, decoded);
+    }
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    public void encodeAndDecodeBrowserVersion() {
+        Map<String, Object> encoded = (Map<String, Object>) WEB_CLIENT_VERSION.encode(BrowserVersion.BEST_SUPPORTED);
+        BrowserVersion decoded = (BrowserVersion) WEB_CLIENT_VERSION.decode(encoded);
+        BrowserVersionTraitTest.verify(BrowserVersion.BEST_SUPPORTED, decoded);
+    }
+    
+    private static void verifyEquals(final ProxyConfig expected, final ProxyConfig actual) {
+        assertEquals("Proxy host mismatch", expected.getProxyHost(), actual.getProxyHost());
+        assertEquals("Proxy port mismatch", expected.getProxyPort(), actual.getProxyPort());
+        assertEquals("Proxy scheme mismatch", expected.getProxyScheme(), actual.getProxyScheme());
+        assertEquals("Proxy type mismatch", expected.isSocksProxy(), actual.isSocksProxy());
+        assertEquals("Proxy bypass hosts mismatrch",
+                ProxyConfigBean.getBypassHosts(expected), ProxyConfigBean.getBypassHosts(actual));
+    }
+}


### PR DESCRIPTION
This PR is primarily focused on implementing complete configurability through a new **HtmlUnitDriverOptions** class, which is an extension of **MutableCapabilities**. This options class adheres to the standard format, storing all driver-specific options under a new `garg:htmlunitOptions` key. The object stored under this key supports options for all settings of the **WebClientOptions** and **BrowserVersion** classes.  

In addition to enhanced configurability:
* Minor modifications were made to **HtmlUnitDriver**, **ElementMap**, and **HtmlUnitWebElement** to enable JSON serialization and deserialization. These facilities are necessary for remote operation of the driver.
* Unit tests were added for new classes and methods.
* TODO comments were added on stub functions in the **Algorithms** class.