### PR TITLE
Use Capabilities API to set options

### DIFF
--- a/src/test/java/org/openqa/selenium/htmlunit/WebDriverTestCase.java
+++ b/src/test/java/org/openqa/selenium/htmlunit/WebDriverTestCase.java
@@ -108,6 +108,7 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.firefox.GeckoDriverService;
 import org.openqa.selenium.htmlunit.options.HtmlUnitDriverOptions;
+import org.openqa.selenium.htmlunit.options.HtmlUnitOption;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 
 /**
@@ -541,19 +542,16 @@ public abstract class WebDriverTestCase extends WebTestCase {
             throw new RuntimeException("Unexpected BrowserVersion: " + getBrowserVersion());
         }
         if (webDriver_ == null) {
-            final WebClientOptions options = new WebClientOptions();
-            if (isWebClientCached()) {
-                options.setHistorySizeLimit(0);
-            }
-
-            final Integer timeout = getWebClientTimeout();
-            if (timeout != null) {
-                options.setTimeout(timeout.intValue());
-            }
-
             final HtmlUnitDriverOptions driverOptions = new HtmlUnitDriverOptions(getBrowserVersion());
-            driverOptions.importOptions(options);
-
+            
+            if (isWebClientCached()) {
+                driverOptions.setCapability(HtmlUnitOption.optHistorySizeLimit, 0);
+            }
+            
+            if (getWebClientTimeout() != null) {
+                driverOptions.setCapability(HtmlUnitOption.optTimeout, getWebClientTimeout());
+            }
+            
             webDriver_ = new HtmlUnitDriver(driverOptions);
             webDriver_.setExecutor(EXECUTOR_POOL);
         }


### PR DESCRIPTION
### **User description**
Instead of using the `importOptions` method to duplicate every option, set the individual options directly via the **Capabilities** API.


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced the use of `WebClientOptions` with `HtmlUnitDriverOptions` for setting up the WebDriver.
- Set individual options directly via the `HtmlUnitOption` capabilities API.
- Removed the `importOptions` method to streamline option setting.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebDriverTestCase.java</strong><dd><code>Use Capabilities API for setting HtmlUnitDriver options</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
src/test/java/org/openqa/selenium/htmlunit/WebDriverTestCase.java

<li>Replaced <code>WebClientOptions</code> with <code>HtmlUnitDriverOptions</code>.<br> <li> Set individual options directly using <code>HtmlUnitOption</code> capabilities.<br> <li> Removed the use of <code>importOptions</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/htmlunit-driver/pull/150/files#diff-acf65a9c44ad55991d5361ef64e015d57cf1e647a8b45e69412a626b6bc5ff51">+8/-10</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

